### PR TITLE
Add generic trait to allow real cryptography

### DIFF
--- a/bft-lib/Cargo.toml
+++ b/bft-lib/Cargo.toml
@@ -13,7 +13,7 @@ simulator = []
 
 [dependencies]
 env_logger = "0.8.1"
-failure = "0.1.5"
+anyhow = "1.0"
 log = "0.4.6"
 rand = "0.7.3"
 rand_distr = "0.3.0"

--- a/bft-lib/Cargo.toml
+++ b/bft-lib/Cargo.toml
@@ -19,4 +19,7 @@ rand = "0.7.3"
 rand_distr = "0.3.0"
 clap = "2.33"
 csv = "1.1"
+bcs = "0.1.2"
+serde = { version = "1.0", features = ["derive"] }
+serde-name = "0.1.1"
 futures = { version = "0.3.14", features = ["executor"] }

--- a/bft-lib/src/base_types.rs
+++ b/bft-lib/src/base_types.rs
@@ -23,7 +23,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub struct Round(pub usize);
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash)]
 pub struct NodeTime(pub i64);
-pub type Duration = i64;
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Default)]
+pub struct Duration(pub i64);
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
 pub struct Author(pub usize);
@@ -81,7 +82,7 @@ impl std::ops::Add<Duration> for NodeTime {
     type Output = NodeTime;
 
     fn add(self, rhs: Duration) -> Self::Output {
-        NodeTime(self.0 + rhs)
+        NodeTime(self.0 + rhs.0)
     }
 }
 

--- a/bft-lib/src/base_types.rs
+++ b/bft-lib/src/base_types.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Calibra Research
 // SPDX-License-Identifier: Apache-2.0
 
-use failure::{ensure, Error};
+use anyhow::{ensure, Error};
 use std::{
     collections::hash_map::DefaultHasher,
     fmt,
@@ -12,7 +12,7 @@ use std::{
 #[path = "unit_tests/base_type_tests.rs"]
 mod base_type_tests;
 
-// TODO: add error handling + remove Unpin
+// TODO: add error handling (using thiserror to define an error type?) + remove Unpin
 // Alternatively, we may want to use a generic associated type when there are available on
 // rust-stable:   https://github.com/rust-lang/rust/issues/44265
 pub type AsyncResult<T> = Box<dyn std::future::Future<Output = T> + Unpin + 'static>;

--- a/bft-lib/src/base_types.rs
+++ b/bft-lib/src/base_types.rs
@@ -1,12 +1,9 @@
 // Copyright (c) Calibra Research
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{ensure, Error};
-use std::{
-    collections::hash_map::DefaultHasher,
-    fmt,
-    hash::{Hash, Hasher},
-};
+use anyhow::Error;
+use serde::{Deserialize, Serialize};
+use std::fmt;
 
 #[cfg(test)]
 #[path = "unit_tests/base_type_tests.rs"]
@@ -19,28 +16,17 @@ pub type AsyncResult<T> = Box<dyn std::future::Future<Output = T> + Unpin + 'sta
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, Debug)]
 pub struct Round(pub usize);
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
 pub struct NodeTime(pub i64);
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Default)]
+#[derive(
+    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, Debug, Default,
+)]
 pub struct Duration(pub i64);
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
-pub struct Author(pub usize);
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
-pub struct Signature(pub u64);
-
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, Debug)]
 pub struct EpochId(pub usize);
-
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Debug)]
-pub struct State(pub u64);
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Debug)]
-pub struct Command {
-    pub proposer: Author,
-    pub index: usize,
-}
 
 impl EpochId {
     pub fn previous(self) -> Option<EpochId> {
@@ -83,23 +69,6 @@ impl std::ops::Add<Duration> for NodeTime {
 
     fn add(self, rhs: Duration) -> Self::Output {
         NodeTime(self.0 + rhs.0)
-    }
-}
-
-impl Signature {
-    pub fn sign(hash: u64, author: Author) -> Self {
-        let mut hasher = DefaultHasher::new();
-        hash.hash(&mut hasher);
-        author.hash(&mut hasher);
-        Signature(hasher.finish())
-    }
-
-    pub fn check(&self, hash: u64, author: Author) -> Result<()> {
-        let mut hasher = DefaultHasher::new();
-        hash.hash(&mut hasher);
-        author.hash(&mut hasher);
-        ensure!(hasher.finish() == self.0, "Signatures must be valid.");
-        Ok(())
     }
 }
 

--- a/bft-lib/src/base_types.rs
+++ b/bft-lib/src/base_types.rs
@@ -12,6 +12,11 @@ use std::{
 #[path = "unit_tests/base_type_tests.rs"]
 mod base_type_tests;
 
+// TODO: add error handling + remove Unpin
+// Alternatively, we may want to use a generic associated type when there are available on
+// rust-stable:   https://github.com/rust-lang/rust/issues/44265
+pub type AsyncResult<T> = Box<dyn std::future::Future<Output = T> + Unpin + 'static>;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]

--- a/bft-lib/src/configuration.rs
+++ b/bft-lib/src/configuration.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Calibra Research
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::base_types::Author;
 use std::collections::BTreeMap;
 
 #[cfg(test)]
@@ -10,12 +9,15 @@ mod configuration_tests;
 
 #[derive(Eq, PartialEq, Clone, Debug)]
 /// Represent BFT permissions during an epoch.
-pub struct EpochConfiguration {
+pub struct EpochConfiguration<Author> {
     voting_rights: BTreeMap<Author, usize>,
     total_votes: usize,
 }
 
-impl EpochConfiguration {
+impl<Author> EpochConfiguration<Author>
+where
+    Author: std::cmp::Ord + Clone,
+{
     pub fn new(voting_rights: BTreeMap<Author, usize>) -> Self {
         let total_votes = voting_rights.iter().fold(0, |sum, (_, votes)| sum + *votes);
         EpochConfiguration {
@@ -54,7 +56,7 @@ impl EpochConfiguration {
         let mut target = seed as usize % self.total_votes;
         for (author, votes) in &self.voting_rights {
             if *votes > target {
-                return *author;
+                return author.clone();
             }
             target -= *votes;
         }

--- a/bft-lib/src/data_writer.rs
+++ b/bft-lib/src/data_writer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    base_types::Author,
+    simulated_context::Author,
     simulator::{ActiveRound, Event, GlobalTime, Simulator},
 };
 use std::{fs, path::Path};

--- a/bft-lib/src/data_writer.rs
+++ b/bft-lib/src/data_writer.rs
@@ -3,8 +3,7 @@
 
 use crate::{
     base_types::Author,
-    simulator::{Event, GlobalTime, Simulator},
-    ActiveRound,
+    simulator::{ActiveRound, Event, GlobalTime, Simulator},
 };
 use std::{fs, path::Path};
 

--- a/bft-lib/src/interfaces.rs
+++ b/bft-lib/src/interfaces.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Calibra Research
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    base_types::{Author, NodeTime},
-    AsyncResult,
-};
+use crate::base_types::{AsyncResult, Author, NodeTime};
 
 // -- BEGIN FILE node_update_actions --
 /// Actions required by `ConsensusNode::update_node`.

--- a/bft-lib/src/lib.rs
+++ b/bft-lib/src/lib.rs
@@ -28,8 +28,3 @@ pub use simulator::ActiveRound;
 pub use configuration::EpochConfiguration;
 
 pub use interfaces::*;
-
-// TODO: add error handling + remove Unpin
-// Alternatively, we may want to use a generic associated type when there are available on
-// rust-stable:   https://github.com/rust-lang/rust/issues/44265
-pub type AsyncResult<T> = Box<dyn std::future::Future<Output = T> + Unpin + 'static>;

--- a/bft-lib/src/lib.rs
+++ b/bft-lib/src/lib.rs
@@ -4,9 +4,9 @@
 /// Commond definitions.
 pub mod base_types;
 
-mod configuration;
+pub mod configuration;
 
-mod interfaces;
+pub mod interfaces;
 
 /// Requirements for the external modules provided by `Context`.
 pub mod smr_context;
@@ -21,10 +21,3 @@ pub mod simulator;
 #[cfg(feature = "simulator")]
 /// Implementation of SMR Context
 pub mod simulated_context;
-
-#[cfg(feature = "simulator")]
-pub use simulator::ActiveRound;
-
-pub use configuration::EpochConfiguration;
-
-pub use interfaces::*;

--- a/bft-lib/src/simulated_context.rs
+++ b/bft-lib/src/simulated_context.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{base_types::*, configuration::EpochConfiguration, smr_context::*};
+use anyhow::ensure;
 use log::{debug, error, info};
+use serde::{Deserialize, Serialize};
 use std::{
     collections::{hash_map::DefaultHasher, BTreeMap, HashMap},
+    fmt::Debug,
     hash::{Hash, Hasher},
 };
 
@@ -12,7 +15,24 @@ use std::{
 #[path = "unit_tests/simulated_context_tests.rs"]
 mod simulated_context_tests;
 
-#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+pub struct Author(pub usize);
+#[derive(
+    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize, Default,
+)]
+pub struct Signature(pub usize, pub u64);
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+pub struct HashValue(pub u64);
+
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Debug, Serialize, Deserialize)]
+pub struct State(pub u64);
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Debug, Serialize, Deserialize)]
+pub struct Command {
+    pub proposer: Author,
+    pub index: usize,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Hash, Serialize, Deserialize)]
 pub struct SimulatedLedgerState {
     /// All the executed commands and theirs consensus times of execution.
     /// TODO: use linked lists with sharing
@@ -49,9 +69,9 @@ impl SimulatedLedgerState {
     }
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SimulatedContext {
-    config: Config,
+    config: Config<Author>,
     num_nodes: usize,
     max_command_per_epoch: usize,
     next_fetched_command_index: usize,
@@ -59,8 +79,27 @@ pub struct SimulatedContext {
     pending_ledger_states: HashMap<State, SimulatedLedgerState>,
 }
 
+// TODO: remove (see comment in SmrContext)
+impl std::cmp::PartialOrd for SimulatedContext {
+    fn partial_cmp(&self, _other: &Self) -> Option<std::cmp::Ordering> {
+        panic!("not implemented");
+    }
+}
+impl std::cmp::Ord for SimulatedContext {
+    fn cmp(&self, _other: &Self) -> std::cmp::Ordering {
+        panic!("not implemented");
+    }
+}
+impl std::cmp::PartialEq for SimulatedContext {
+    fn eq(&self, _other: &Self) -> bool {
+        panic!("not implemented");
+    }
+}
+
+impl std::cmp::Eq for SimulatedContext {}
+
 impl SimulatedContext {
-    pub fn new(config: Config, num_nodes: usize, max_command_per_epoch: usize) -> Self {
+    pub fn new(config: Config<Author>, num_nodes: usize, max_command_per_epoch: usize) -> Self {
         SimulatedContext {
             config,
             num_nodes,
@@ -88,7 +127,12 @@ impl SimulatedContext {
     }
 }
 
-impl CommandFetcher for SimulatedContext {
+impl ContextTypes for SimulatedContext {
+    type State = State;
+    type Command = Command;
+}
+
+impl CommandFetcher<Command> for SimulatedContext {
     fn fetch(&mut self) -> Option<Command> {
         let command = Command {
             proposer: self.config.author,
@@ -99,7 +143,7 @@ impl CommandFetcher for SimulatedContext {
     }
 }
 
-impl StateComputer for SimulatedContext {
+impl CommandExecutor<Author, State, Command> for SimulatedContext {
     fn compute(
         &mut self,
         base_state: &State,
@@ -132,12 +176,8 @@ impl StateComputer for SimulatedContext {
     }
 }
 
-pub trait CommitCertificate {
-    fn committed_state(&self) -> Option<&State>;
-}
-
-impl<C: CommitCertificate> StateFinalizer<C> for SimulatedContext {
-    fn commit(&mut self, state: &State, certificate: Option<&C>) {
+impl StateFinalizer<State> for SimulatedContext {
+    fn commit(&mut self, state: &State, certificate: Option<&dyn CommitCertificate<State>>) {
         info!(
             "{:?} Delivering commit for state: {:?}",
             self.config.author, state
@@ -177,7 +217,7 @@ impl<C: CommitCertificate> StateFinalizer<C> for SimulatedContext {
     }
 }
 
-impl EpochReader for SimulatedContext {
+impl EpochReader<Author, State> for SimulatedContext {
     fn read_epoch_id(&self, state: &State) -> EpochId {
         let num_commands = self
             .get_ledger_state(state)
@@ -187,7 +227,7 @@ impl EpochReader for SimulatedContext {
         EpochId(num_commands / self.max_command_per_epoch)
     }
 
-    fn configuration(&self, _state: &State) -> EpochConfiguration {
+    fn configuration(&self, _state: &State) -> EpochConfiguration<Author> {
         // We do not simulate changes in the voting rights yet.
         let mut voting_rights = BTreeMap::new();
         for index in 0..self.num_nodes {
@@ -197,8 +237,53 @@ impl EpochReader for SimulatedContext {
     }
 }
 
-impl Storage for SimulatedContext {
-    fn config(&self) -> &Config {
+#[derive(Default)]
+pub struct SimulatedHasher(std::collections::hash_map::DefaultHasher);
+
+impl std::io::Write for SimulatedHasher {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.write(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl CryptographicModule for SimulatedContext {
+    type Hasher = SimulatedHasher;
+    type Author = Author;
+    type Signature = Signature;
+    type HashValue = u64;
+
+    fn hash(&self, message: &dyn Signable<Self::Hasher>) -> Self::HashValue {
+        let mut hasher = SimulatedHasher::default();
+        message.write(&mut hasher);
+        hasher.0.finish()
+    }
+
+    fn verify(
+        &self,
+        author: Self::Author,
+        hash: Self::HashValue,
+        signature: Self::Signature,
+    ) -> Result<()> {
+        ensure!(author.0 == signature.0, "Unexpected signer in signature");
+        ensure!(hash == signature.1, "Unexpected hash in signature");
+        Ok(())
+    }
+
+    fn author(&self) -> &Self::Author {
+        &self.config.author
+    }
+
+    fn sign(&mut self, hash: Self::HashValue) -> Result<Self::Signature> {
+        Ok(Signature(self.config.author.0, hash))
+    }
+}
+
+impl Storage<Author, State> for SimulatedContext {
+    fn config(&self) -> &Config<Author> {
         &self.config
     }
 
@@ -207,4 +292,4 @@ impl Storage for SimulatedContext {
     }
 }
 
-impl<C: CommitCertificate> SmrContext<C> for SimulatedContext {}
+impl SmrContext for SimulatedContext {}

--- a/bft-lib/src/simulated_context.rs
+++ b/bft-lib/src/simulated_context.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Calibra Research
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{base_types::*, smr_context::*, EpochConfiguration};
+use crate::{base_types::*, configuration::EpochConfiguration, smr_context::*};
 use log::{debug, error, info};
 use std::{
     collections::{hash_map::DefaultHasher, BTreeMap, HashMap},

--- a/bft-lib/src/simulator.rs
+++ b/bft-lib/src/simulator.rs
@@ -4,7 +4,7 @@
 use crate::{
     base_types::{Author, Duration, NodeTime, Round},
     data_writer::DataWriter,
-    ConsensusNode, DataSyncNode, NodeUpdateActions,
+    interfaces::{ConsensusNode, DataSyncNode, NodeUpdateActions},
 };
 use futures::executor::block_on;
 use log::{debug, trace};

--- a/bft-lib/src/simulator.rs
+++ b/bft-lib/src/simulator.rs
@@ -29,7 +29,7 @@ impl std::ops::Add<Duration> for GlobalTime {
     type Output = GlobalTime;
 
     fn add(self, rhs: Duration) -> Self::Output {
-        GlobalTime(self.0 + rhs)
+        GlobalTime(self.0 + rhs.0)
     }
 }
 
@@ -155,7 +155,7 @@ where
             .map(|index| {
                 let author = Author(index);
                 let mut context = context_factory(author, num_nodes);
-                let startup_time = clock.add_delay(network_delay) + 1;
+                let startup_time = clock.add_delay(network_delay) + Duration(1);
                 let node_time = NodeTime(0);
                 let deadline = GlobalTime::from_node_time(node_time, startup_time);
                 let event = Event::UpdateTimerEvent { author };
@@ -168,7 +168,7 @@ where
                 pending_events.push(ScheduledEvent(std::cmp::Reverse(deadline), event));
                 SimulatedNode {
                     startup_time,
-                    ignore_scheduled_updates_until: startup_time + (-1),
+                    ignore_scheduled_updates_until: startup_time + Duration(-1),
                     node,
                     context,
                 }
@@ -241,10 +241,10 @@ where
                 GlobalTime::from_node_time(actions.next_scheduled_update, node.startup_time),
                 // Make sure we schedule the update strictly in the future so it does not get
                 // ignored by `ignore_scheduled_updates_until` below.
-                clock + 1,
+                clock + Duration(1),
             );
             // We don't remove the previously scheduled updates but this will cancel them.
-            node.ignore_scheduled_updates_until = new_deadline + (-1);
+            node.ignore_scheduled_updates_until = new_deadline + Duration(-1);
             new_deadline
             // scoping the mutable 'node' for the borrow checker
         };

--- a/bft-lib/src/smr_context.rs
+++ b/bft-lib/src/smr_context.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Calibra Research
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{base_types::*, EpochConfiguration};
+use crate::{base_types::*, configuration::EpochConfiguration};
 
 // -- BEGIN FILE smr_apis --
 pub trait CommandFetcher {

--- a/bft-lib/src/unit_tests/base_type_tests.rs
+++ b/bft-lib/src/unit_tests/base_type_tests.rs
@@ -7,11 +7,3 @@ use super::*;
 fn test_round_plus_usize() {
     assert_eq!(Round(3) + 4, Round(7));
 }
-
-#[test]
-fn test_signature() {
-    let sig = Signature::sign(35, Author(2));
-    assert!(sig.check(35, Author(2)).is_ok());
-    assert!(sig.check(32, Author(2)).is_err());
-    assert!(sig.check(35, Author(1)).is_err());
-}

--- a/bft-lib/src/unit_tests/configuration_tests.rs
+++ b/bft-lib/src/unit_tests/configuration_tests.rs
@@ -6,22 +6,22 @@ use super::*;
 #[test]
 fn test_count() {
     let mut rights = BTreeMap::new();
-    rights.insert(Author(0), 1);
-    rights.insert(Author(1), 2);
-    rights.insert(Author(2), 3);
+    rights.insert("0", 1);
+    rights.insert("1", 2);
+    rights.insert("2", 3);
     let config = EpochConfiguration::new(rights);
     assert_eq!(config.total_votes, 6);
 
-    assert_eq!(config.count_votes(vec![&Author(1)]), 2);
-    assert_eq!(config.count_votes(vec![&Author(4)]), 0);
+    assert_eq!(config.count_votes(vec![&"1"]), 2);
+    assert_eq!(config.count_votes(vec![&"4"]), 0);
 }
 
 #[test]
 fn test_pick_author() {
     let mut rights = BTreeMap::new();
-    rights.insert(Author(0), 1);
-    rights.insert(Author(1), 2);
-    rights.insert(Author(2), 5);
+    rights.insert("0", 1);
+    rights.insert("1", 2);
+    rights.insert("2", 5);
     let config = EpochConfiguration::new(rights);
 
     let mut hits = BTreeMap::new();
@@ -34,10 +34,10 @@ fn test_pick_author() {
     assert_eq!(vec![1, 2, 5], results);
 }
 
-fn equal_configuration(num_nodes: usize) -> EpochConfiguration {
+fn equal_configuration(num_nodes: usize) -> EpochConfiguration<usize> {
     let mut voting_rights = BTreeMap::new();
     for index in 0..num_nodes {
-        voting_rights.insert(Author(index), 1);
+        voting_rights.insert(index, 1);
     }
     EpochConfiguration::new(voting_rights)
 }

--- a/bft-lib/src/unit_tests/simulated_context_tests.rs
+++ b/bft-lib/src/unit_tests/simulated_context_tests.rs
@@ -2,6 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct Foo(u32);
+#[derive(Serialize, Deserialize)]
+struct Bar(u32);
+
+#[test]
+fn test_hashing_and_signing() {
+    let mut context = SimulatedContext::new(
+        Config::new(Author(0)),
+        /* num_nodes */ 2,
+        /* max commands per epoch */ 2,
+    );
+    let h1 = context.hash(&Foo(35));
+    let h2 = context.hash(&Bar(35));
+
+    let sig1 = context.sign(h1).unwrap();
+    assert!(context.verify(Author(0), h1, sig1).is_ok());
+    assert!(context.verify(Author(1), h1, sig1).is_err());
+    assert!(context.verify(Author(0), h2, sig1).is_err());
+
+    let bytes = bcs::to_bytes(&Foo(35)).unwrap();
+    let mut hasher = DefaultHasher::default();
+    hasher.write(b"Foo::");
+    hasher.write(&bytes);
+    let h = hasher.finish();
+    assert_eq!(h1, h);
+}
 
 #[test]
 fn test_happened_before() {
@@ -34,9 +63,10 @@ fn test_happened_before() {
     assert!(!s2.happened_just_before(&s1));
 }
 
+#[derive(Hash, Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 struct DummyCertificate;
 
-impl CommitCertificate for DummyCertificate {
+impl CommitCertificate<State> for DummyCertificate {
     fn committed_state(&self) -> Option<&State> {
         None
     }
@@ -69,9 +99,9 @@ fn test_simulated_context() {
         .unwrap();
     assert_eq!(context.read_epoch_id(&s3), EpochId(0));
 
-    StateFinalizer::<DummyCertificate>::commit(&mut context, &s1, None);
-    StateFinalizer::<DummyCertificate>::commit(&mut context, &s2, None);
-    StateFinalizer::<DummyCertificate>::discard(&mut context, &s3);
+    StateFinalizer::<State>::commit(&mut context, &s1, None);
+    StateFinalizer::<State>::commit(&mut context, &s2, Some(&DummyCertificate));
+    StateFinalizer::<State>::discard(&mut context, &s3);
 
     assert_eq!(
         context.last_committed_ledger_state.execution_history,

--- a/librabft-v2/Cargo.toml
+++ b/librabft-v2/Cargo.toml
@@ -13,7 +13,7 @@ simulator = ["bft-lib/simulator"]
 
 [dependencies]
 env_logger = "0.8.1"
-failure = "0.1.5"
+anyhow = "1.0"
 log = "0.4.6"
 rand = "0.7.3"
 clap = "2.33"

--- a/librabft-v2/Cargo.toml
+++ b/librabft-v2/Cargo.toml
@@ -19,6 +19,7 @@ rand = "0.7.3"
 clap = "2.33"
 csv = "1.1"
 futures = "0.3.14"
+serde = { version = "1.0", features = ["derive"] }
 
 bft-lib = { path = "../bft-lib" }
 

--- a/librabft-v2/src/base_types.rs
+++ b/librabft-v2/src/base_types.rs
@@ -1,15 +1,17 @@
 // Copyright (c) Calibra Research
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{Deserialize, Serialize};
+
 #[cfg(test)]
 #[path = "unit_tests/base_type_tests.rs"]
 mod base_type_tests;
 
 // The following types are simplified for simulation purposes.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
-pub(crate) struct BlockHash(pub u64);
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
-pub(crate) struct QuorumCertificateHash(pub u64);
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+pub(crate) struct BlockHash<V>(pub V);
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+pub(crate) struct QuorumCertificateHash<V>(pub V);
 
 pub(crate) fn is_power2_minus1(x: usize) -> bool {
     (x & (x + 1)) == 0

--- a/librabft-v2/src/base_types.rs
+++ b/librabft-v2/src/base_types.rs
@@ -7,15 +7,15 @@ mod base_type_tests;
 
 // The following types are simplified for simulation purposes.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
-pub struct BlockHash(pub u64);
+pub(crate) struct BlockHash(pub u64);
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
-pub struct QuorumCertificateHash(pub u64);
+pub(crate) struct QuorumCertificateHash(pub u64);
 
-pub fn is_power2_minus1(x: usize) -> bool {
+pub(crate) fn is_power2_minus1(x: usize) -> bool {
     (x & (x + 1)) == 0
 }
 
-pub fn merge_sort<T: Eq, I: IntoIterator<Item = T>, F: Fn(&T, &T) -> std::cmp::Ordering>(
+pub(crate) fn merge_sort<T: Eq, I: IntoIterator<Item = T>, F: Fn(&T, &T) -> std::cmp::Ordering>(
     v1: I,
     v2: I,
     cmp: F,

--- a/librabft-v2/src/data_sync.rs
+++ b/librabft-v2/src/data_sync.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{node::*, record::*};
-use bft_lib::{base_types::*, smr_context::SmrContext, AsyncResult, DataSyncNode};
+use bft_lib::{base_types::*, smr_context::SmrContext, DataSyncNode};
 use futures::future;
 use std::collections::BTreeSet;
 

--- a/librabft-v2/src/data_sync.rs
+++ b/librabft-v2/src/data_sync.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{node::*, record::*};
-use bft_lib::{base_types::*, smr_context::SmrContext, DataSyncNode};
+use bft_lib::{base_types::*, interfaces::DataSyncNode, smr_context::SmrContext};
 use futures::future;
 use std::collections::BTreeSet;
 

--- a/librabft-v2/src/main.rs
+++ b/librabft-v2/src/main.rs
@@ -24,11 +24,11 @@ fn main() {
     };
     let delay_distribution = simulator::RandomDelay::new(args.mean, args.variance);
     let mut sim = simulator::Simulator::<
-        NodeState,
+        NodeState<SimulatedContext>,
         SimulatedContext,
-        DataSyncNotification,
+        DataSyncNotification<SimulatedContext>,
         DataSyncRequest,
-        DataSyncResponse,
+        DataSyncResponse<SimulatedContext>,
     >::new(args.nodes, delay_distribution, context_factory);
     let contexts = sim.loop_until(
         simulator::GlobalTime(args.max_clock),

--- a/librabft-v2/src/main.rs
+++ b/librabft-v2/src/main.rs
@@ -138,16 +138,14 @@ fn get_arguments() -> CliArguments {
             .unwrap()
             .parse::<usize>()
             .unwrap(),
-        target_commit_interval: matches
-            .value_of("target_commit_interval")
-            .unwrap()
-            .parse::<Duration>()
-            .unwrap(),
-        delta: matches
-            .value_of("delta")
-            .unwrap()
-            .parse::<Duration>()
-            .unwrap(),
+        target_commit_interval: Duration(
+            matches
+                .value_of("target_commit_interval")
+                .unwrap()
+                .parse::<i64>()
+                .unwrap(),
+        ),
+        delta: Duration(matches.value_of("delta").unwrap().parse::<i64>().unwrap()),
         gamma: matches.value_of("gamma").unwrap().parse::<f64>().unwrap(),
         lambda: matches.value_of("lambda").unwrap().parse::<f64>().unwrap(),
         output_data_files: matches.value_of("create_csv").map(|x| x.to_string()),

--- a/librabft-v2/src/node.rs
+++ b/librabft-v2/src/node.rs
@@ -47,7 +47,7 @@ pub struct NodeState {
 
 // -- BEGIN FILE commit_tracker --
 #[derive(Debug)]
-pub struct CommitTracker {
+struct CommitTracker {
     /// Latest epoch identifier that was processed.
     epoch_id: EpochId,
     /// Round of the latest commit that was processed.
@@ -108,19 +108,19 @@ impl NodeState {
         QuorumCertificateHash(id.0 as u64)
     }
 
-    pub fn epoch_id(&self) -> EpochId {
+    pub(crate) fn epoch_id(&self) -> EpochId {
         self.epoch_id
     }
 
-    pub fn local_author(&self) -> Author {
+    pub(crate) fn local_author(&self) -> Author {
         self.local_author
     }
 
-    pub fn record_store(&self) -> &dyn RecordStore {
+    pub(crate) fn record_store(&self) -> &dyn RecordStore {
         &self.record_store
     }
 
-    pub fn record_store_at(&self, epoch_id: EpochId) -> Option<&dyn RecordStore> {
+    pub(crate) fn record_store_at(&self, epoch_id: EpochId) -> Option<&dyn RecordStore> {
         if epoch_id == self.epoch_id {
             return Some(&self.record_store);
         }
@@ -129,11 +129,11 @@ impl NodeState {
             .map(|store| &*store as &dyn RecordStore)
     }
 
-    pub fn pacemaker(&self) -> &dyn Pacemaker {
+    pub(crate) fn pacemaker(&self) -> &dyn Pacemaker {
         &self.pacemaker
     }
 
-    pub fn update_tracker(&mut self, clock: NodeTime) {
+    pub(crate) fn update_tracker(&mut self, clock: NodeTime) {
         // Ignore actions
         self.tracker.update_tracker(
             self.latest_query_all_time,
@@ -143,7 +143,7 @@ impl NodeState {
         );
     }
 
-    pub fn insert_network_record(
+    pub(crate) fn insert_network_record(
         &mut self,
         epoch_id: EpochId,
         record: Record,
@@ -281,7 +281,7 @@ impl<Context: SmrContext<QuorumCertificate>> ConsensusNode<Context> for NodeStat
 
 // -- BEGIN FILE process_commits --
 impl NodeState {
-    pub fn process_commits(&mut self, context: &mut dyn SmrContext<QuorumCertificate>) {
+    pub(crate) fn process_commits(&mut self, context: &mut dyn SmrContext<QuorumCertificate>) {
         // For all commits that have not been processed yet, according to the commit tracker..
         for (round, state) in self
             .record_store
@@ -321,7 +321,7 @@ impl NodeState {
 
 // -- BEGIN FILE commit_tracker_impl --
 #[derive(Debug)]
-pub struct CommitTrackerUpdateActions {
+struct CommitTrackerUpdateActions {
     /// Time at which to call `update_node` again, at the latest.
     next_scheduled_update: NodeTime,
     /// Whether we need to query all other nodes.

--- a/librabft-v2/src/node.rs
+++ b/librabft-v2/src/node.rs
@@ -5,7 +5,10 @@
 
 use crate::{base_types::QuorumCertificateHash, pacemaker::*, record::*, record_store::*};
 use bft_lib::{
-    base_types::*, smr_context, smr_context::SmrContext, ConsensusNode, NodeUpdateActions,
+    base_types::*,
+    interfaces::{ConsensusNode, NodeUpdateActions},
+    smr_context,
+    smr_context::SmrContext,
 };
 use futures::future;
 use log::debug;
@@ -158,7 +161,7 @@ impl NodeState {
 }
 
 #[cfg(feature = "simulator")]
-impl bft_lib::ActiveRound for NodeState {
+impl bft_lib::simulator::ActiveRound for NodeState {
     fn active_round(&self) -> Round {
         self.pacemaker.active_round()
     }

--- a/librabft-v2/src/node.rs
+++ b/librabft-v2/src/node.rs
@@ -5,8 +5,7 @@
 
 use crate::{base_types::QuorumCertificateHash, pacemaker::*, record::*, record_store::*};
 use bft_lib::{
-    base_types::*, smr_context, smr_context::SmrContext, AsyncResult, ConsensusNode,
-    NodeUpdateActions,
+    base_types::*, smr_context, smr_context::SmrContext, ConsensusNode, NodeUpdateActions,
 };
 use futures::future;
 use log::debug;

--- a/librabft-v2/src/node.rs
+++ b/librabft-v2/src/node.rs
@@ -23,15 +23,15 @@ mod node_tests;
 
 // -- BEGIN FILE node_state --
 #[derive(Debug)]
-pub struct NodeState {
+pub struct NodeState<Context: SmrContext> {
     /// Module dedicated to storing records for the current epoch.
-    record_store: RecordStoreState,
+    record_store: RecordStoreState<Context>,
     /// Module dedicated to leader election.
-    pacemaker: PacemakerState,
+    pacemaker: PacemakerState<Context>,
     /// Current epoch.
     epoch_id: EpochId,
     /// Identity of this node.
-    local_author: Author,
+    local_author: Context::Author,
     /// Highest round voted so far.
     latest_voted_round: Round,
     /// Current locked round.
@@ -41,7 +41,7 @@ pub struct NodeState {
     /// Track data to which the main handler has already reacted.
     tracker: CommitTracker,
     /// Record stores from previous epochs.
-    past_record_stores: HashMap<EpochId, RecordStoreState>,
+    past_record_stores: HashMap<EpochId, RecordStoreState<Context>>,
 }
 // -- END FILE --
 
@@ -70,17 +70,20 @@ impl CommitTracker {
     }
 }
 
-impl NodeState {
+impl<Context> NodeState<Context>
+where
+    Context: SmrContext,
+{
     fn new(
-        config: smr_context::Config,
-        initial_state: State,
+        config: smr_context::Config<Context::Author>,
+        initial_state: Context::State,
         node_time: NodeTime,
-        context: &dyn SmrContext<QuorumCertificate>,
-    ) -> NodeState {
+        context: &Context,
+    ) -> Self {
         let epoch_id = EpochId(0);
         let tracker = CommitTracker::new(epoch_id, node_time, config.target_commit_interval);
         let record_store = RecordStoreState::new(
-            Self::initial_hash(epoch_id),
+            Self::initial_hash(context, epoch_id),
             initial_state.clone(),
             epoch_id,
             context.configuration(&initial_state),
@@ -104,32 +107,32 @@ impl NodeState {
         }
     }
 
-    fn initial_hash(id: EpochId) -> QuorumCertificateHash {
-        QuorumCertificateHash(id.0 as u64)
+    fn initial_hash(context: &Context, id: EpochId) -> QuorumCertificateHash<Context::HashValue> {
+        QuorumCertificateHash(context.hash(&id))
     }
 
     pub(crate) fn epoch_id(&self) -> EpochId {
         self.epoch_id
     }
 
-    pub(crate) fn local_author(&self) -> Author {
+    pub(crate) fn local_author(&self) -> Context::Author {
         self.local_author
     }
 
-    pub(crate) fn record_store(&self) -> &dyn RecordStore {
+    pub(crate) fn record_store(&self) -> &dyn RecordStore<Context> {
         &self.record_store
     }
 
-    pub(crate) fn record_store_at(&self, epoch_id: EpochId) -> Option<&dyn RecordStore> {
+    pub(crate) fn record_store_at(&self, epoch_id: EpochId) -> Option<&dyn RecordStore<Context>> {
         if epoch_id == self.epoch_id {
             return Some(&self.record_store);
         }
         self.past_record_stores
             .get(&epoch_id)
-            .map(|store| &*store as &dyn RecordStore)
+            .map(|store| &*store as &dyn RecordStore<Context>)
     }
 
-    pub(crate) fn pacemaker(&self) -> &dyn Pacemaker {
+    pub(crate) fn pacemaker(&self) -> &dyn Pacemaker<Context> {
         &self.pacemaker
     }
 
@@ -146,8 +149,8 @@ impl NodeState {
     pub(crate) fn insert_network_record(
         &mut self,
         epoch_id: EpochId,
-        record: Record,
-        context: &mut dyn SmrContext<QuorumCertificate>,
+        record: Record<Context>,
+        context: &mut Context,
     ) {
         if epoch_id == self.epoch_id {
             self.record_store.insert_network_record(record, context);
@@ -161,25 +164,26 @@ impl NodeState {
 }
 
 #[cfg(feature = "simulator")]
-impl bft_lib::simulator::ActiveRound for NodeState {
+impl<Context: SmrContext> bft_lib::simulator::ActiveRound for NodeState<Context> {
     fn active_round(&self) -> Round {
         self.pacemaker.active_round()
     }
 }
 
 // -- BEGIN FILE process_pacemaker_actions --
-impl NodeState {
+impl<Context: SmrContext> NodeState<Context> {
     fn process_pacemaker_actions(
         &mut self,
-        pacemaker_actions: PacemakerUpdateActions,
+        pacemaker_actions: PacemakerUpdateActions<Context>,
         clock: NodeTime,
-        context: &mut dyn SmrContext<QuorumCertificate>,
-    ) -> NodeUpdateActions {
-        let mut actions = NodeUpdateActions::new();
-        actions.next_scheduled_update = pacemaker_actions.next_scheduled_update;
-        actions.should_broadcast = pacemaker_actions.should_broadcast;
-        actions.should_query_all = pacemaker_actions.should_query_all;
-        actions.should_send = pacemaker_actions.should_send;
+        context: &mut Context,
+    ) -> NodeUpdateActions<Context> {
+        let actions = NodeUpdateActions {
+            next_scheduled_update: pacemaker_actions.next_scheduled_update,
+            should_broadcast: pacemaker_actions.should_broadcast,
+            should_query_all: pacemaker_actions.should_query_all,
+            should_send: pacemaker_actions.should_send,
+        };
         if let Some(round) = pacemaker_actions.should_create_timeout {
             self.record_store
                 .create_timeout(self.local_author, round, context);
@@ -196,7 +200,10 @@ impl NodeState {
 // -- END FILE --
 
 // -- BEGIN FILE consensus_node_impl --
-impl<Context: SmrContext<QuorumCertificate>> ConsensusNode<Context> for NodeState {
+impl<Context> ConsensusNode<Context> for NodeState<Context>
+where
+    Context: SmrContext,
+{
     fn load_node(context: &mut Context, node_time: NodeTime) -> AsyncResult<Self> {
         let config = context.config().clone();
         let state = context.state();
@@ -209,7 +216,11 @@ impl<Context: SmrContext<QuorumCertificate>> ConsensusNode<Context> for NodeStat
         Box::new(future::ready(()))
     }
 
-    fn update_node(&mut self, context: &mut Context, clock: NodeTime) -> NodeUpdateActions {
+    fn update_node(
+        &mut self,
+        context: &mut Context,
+        clock: NodeTime,
+    ) -> NodeUpdateActions<Context> {
         // Update pacemaker state and process pacemaker actions (e.g., creating a timeout, proposing
         // a block).
         let pacemaker_actions = self.pacemaker.update_pacemaker(
@@ -280,8 +291,11 @@ impl<Context: SmrContext<QuorumCertificate>> ConsensusNode<Context> for NodeStat
 // -- END FILE --
 
 // -- BEGIN FILE process_commits --
-impl NodeState {
-    pub(crate) fn process_commits(&mut self, context: &mut dyn SmrContext<QuorumCertificate>) {
+impl<Context> NodeState<Context>
+where
+    Context: SmrContext,
+{
+    pub(crate) fn process_commits(&mut self, context: &mut Context) {
         // For all commits that have not been processed yet, according to the commit tracker..
         for (round, state) in self
             .record_store
@@ -290,7 +304,10 @@ impl NodeState {
             // .. deliver the committed state to the SMR layer, together with a commit certificate,
             // if any.
             if round == self.record_store.highest_committed_round() {
-                context.commit(&state, self.record_store.highest_commit_certificate())
+                match self.record_store.highest_commit_certificate() {
+                    None => context.commit(&state, None),
+                    Some(x) => context.commit(&state, Some(x)),
+                };
             } else {
                 context.commit(&state, None);
             };
@@ -299,7 +316,7 @@ impl NodeState {
             if new_epoch_id > self.epoch_id {
                 // .. create a new record store and switch to the new epoch.
                 let new_record_store = RecordStoreState::new(
-                    Self::initial_hash(new_epoch_id),
+                    Self::initial_hash(context, new_epoch_id),
                     state.clone(),
                     new_epoch_id,
                     context.configuration(&state),
@@ -329,12 +346,12 @@ struct CommitTrackerUpdateActions {
 }
 
 impl CommitTracker {
-    fn update_tracker(
+    fn update_tracker<Context: SmrContext>(
         &mut self,
         latest_query_all_time: NodeTime,
         clock: NodeTime,
         current_epoch_id: EpochId,
-        current_record_store: &dyn RecordStore,
+        current_record_store: &dyn RecordStore<Context>,
     ) -> CommitTrackerUpdateActions {
         let mut actions = CommitTrackerUpdateActions::new();
         // Update tracked values: epoch, round, and time of the latest commit.

--- a/librabft-v2/src/pacemaker.rs
+++ b/librabft-v2/src/pacemaker.rs
@@ -90,7 +90,7 @@ impl PacemakerState {
             active_round: Round(0),
             active_leader: None,
             active_round_start_time: node_time,
-            active_round_duration: 0,
+            active_round_duration: Duration(0),
             delta,
             gamma,
             lambda,
@@ -115,7 +115,7 @@ impl PacemakerState {
             "Active round is higher than any QC round."
         );
         let n = round.0 - highest_commit_certificate_round.0;
-        ((self.delta as f64) * (n as f64).powf(self.gamma)) as Duration
+        Duration(((self.delta.0 as f64) * (n as f64).powf(self.gamma)) as i64)
     }
 }
 
@@ -189,7 +189,7 @@ impl Pacemaker for PacemakerState {
             }
         } else {
             // Otherwise, enforce frequent query-all actions if we stay too long on the same round.
-            let period = (self.lambda * self.active_round_duration as f64) as i64;
+            let period = Duration((self.lambda * self.active_round_duration.0 as f64) as i64);
             let mut query_all_deadline = latest_query_all_time + period;
             if clock >= query_all_deadline {
                 actions.should_query_all = true;

--- a/librabft-v2/src/pacemaker.rs
+++ b/librabft-v2/src/pacemaker.rs
@@ -15,24 +15,24 @@ mod pacemaker_tests;
 
 // -- BEGIN FILE pacemaker_update_actions --
 #[derive(Debug)]
-pub struct PacemakerUpdateActions {
+pub(crate) struct PacemakerUpdateActions {
     /// Whether to propose a block and on top of which QC hash.
-    pub should_propose_block: Option<QuorumCertificateHash>,
+    pub(crate) should_propose_block: Option<QuorumCertificateHash>,
     /// Whether we should create a timeout object for the given round.
-    pub should_create_timeout: Option<Round>,
+    pub(crate) should_create_timeout: Option<Round>,
     /// Whether we need to send our records to a subset of nodes.
-    pub should_send: Vec<Author>,
+    pub(crate) should_send: Vec<Author>,
     /// Whether we need to broadcast data to all other nodes.
-    pub should_broadcast: bool,
+    pub(crate) should_broadcast: bool,
     /// Whether we need to request data from all other nodes.
-    pub should_query_all: bool,
+    pub(crate) should_query_all: bool,
     /// Time at which to call `update_pacemaker` again, at the latest.
-    pub next_scheduled_update: NodeTime,
+    pub(crate) next_scheduled_update: NodeTime,
 }
 // -- END FILE --
 
 // -- BEGIN FILE pacemaker --
-pub trait Pacemaker: std::fmt::Debug {
+pub(crate) trait Pacemaker: std::fmt::Debug {
     /// Update our state from the given data and return some action items.
     fn update_pacemaker(
         &mut self,
@@ -57,7 +57,7 @@ pub trait Pacemaker: std::fmt::Debug {
 
 // -- BEGIN FILE pacemaker_state --
 #[derive(Debug)]
-pub struct PacemakerState {
+pub(crate) struct PacemakerState {
     /// Active epoch.
     active_epoch: EpochId,
     /// Active round.
@@ -78,7 +78,7 @@ pub struct PacemakerState {
 // -- END FILE --
 
 impl PacemakerState {
-    pub fn new(
+    pub(crate) fn new(
         epoch_id: EpochId,
         node_time: NodeTime,
         delta: Duration,
@@ -97,7 +97,7 @@ impl PacemakerState {
         }
     }
 
-    pub fn leader(record_store: &dyn RecordStore, round: Round) -> Author {
+    pub(crate) fn leader(record_store: &dyn RecordStore, round: Round) -> Author {
         let mut hasher = DefaultHasher::new();
         round.hash(&mut hasher);
         record_store.pick_author(hasher.finish())

--- a/librabft-v2/src/pacemaker.rs
+++ b/librabft-v2/src/pacemaker.rs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{base_types::QuorumCertificateHash, record_store::*};
-use bft_lib::base_types::{Author, Duration, EpochId, NodeTime, Round};
-use std::{
-    cmp::{max, min},
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
+use bft_lib::{
+    base_types::{Duration, EpochId, NodeTime, Round},
+    smr_context::SmrContext,
 };
+use std::cmp::{max, min};
 
 #[cfg(test)]
 #[path = "unit_tests/pacemaker_tests.rs"]
@@ -15,13 +14,13 @@ mod pacemaker_tests;
 
 // -- BEGIN FILE pacemaker_update_actions --
 #[derive(Debug)]
-pub(crate) struct PacemakerUpdateActions {
+pub(crate) struct PacemakerUpdateActions<Context: SmrContext> {
     /// Whether to propose a block and on top of which QC hash.
-    pub(crate) should_propose_block: Option<QuorumCertificateHash>,
+    pub(crate) should_propose_block: Option<QuorumCertificateHash<Context::HashValue>>,
     /// Whether we should create a timeout object for the given round.
     pub(crate) should_create_timeout: Option<Round>,
     /// Whether we need to send our records to a subset of nodes.
-    pub(crate) should_send: Vec<Author>,
+    pub(crate) should_send: Vec<Context::Author>,
     /// Whether we need to broadcast data to all other nodes.
     pub(crate) should_broadcast: bool,
     /// Whether we need to request data from all other nodes.
@@ -32,38 +31,38 @@ pub(crate) struct PacemakerUpdateActions {
 // -- END FILE --
 
 // -- BEGIN FILE pacemaker --
-pub(crate) trait Pacemaker: std::fmt::Debug {
+pub(crate) trait Pacemaker<Context: SmrContext> {
     /// Update our state from the given data and return some action items.
     fn update_pacemaker(
         &mut self,
         // Identity of this node.
-        local_author: Author,
+        local_author: Context::Author,
         // Current epoch.
         epoch_id: EpochId,
         // Known records.
-        record_store: &dyn RecordStore,
+        record_store: &dyn RecordStore<Context>,
         // Local time of the latest query-all by us.
         latest_query_all: NodeTime,
         // Current local time.
         clock: NodeTime,
-    ) -> PacemakerUpdateActions;
+    ) -> PacemakerUpdateActions<Context>;
 
     /// Current active epoch, round, and leader.
     fn active_epoch(&self) -> EpochId;
     fn active_round(&self) -> Round;
-    fn active_leader(&self) -> Option<Author>;
+    fn active_leader(&self) -> Option<Context::Author>;
 }
 // -- END FILE --
 
 // -- BEGIN FILE pacemaker_state --
 #[derive(Debug)]
-pub(crate) struct PacemakerState {
+pub(crate) struct PacemakerState<Context: SmrContext> {
     /// Active epoch.
     active_epoch: EpochId,
     /// Active round.
     active_round: Round,
     /// Leader of the active round.
-    active_leader: Option<Author>,
+    active_leader: Option<Context::Author>,
     /// Time at which we entered the round.
     active_round_start_time: NodeTime,
     /// Maximal duration of the current round.
@@ -77,14 +76,14 @@ pub(crate) struct PacemakerState {
 }
 // -- END FILE --
 
-impl PacemakerState {
+impl<Context: SmrContext> PacemakerState<Context> {
     pub(crate) fn new(
         epoch_id: EpochId,
         node_time: NodeTime,
         delta: Duration,
         gamma: f64,
         lambda: f64,
-    ) -> PacemakerState {
+    ) -> Self {
         PacemakerState {
             active_epoch: epoch_id,
             active_round: Round(0),
@@ -97,13 +96,18 @@ impl PacemakerState {
         }
     }
 
-    pub(crate) fn leader(record_store: &dyn RecordStore, round: Round) -> Author {
+    pub(crate) fn leader(record_store: &dyn RecordStore<Context>, round: Round) -> Context::Author {
+        use std::{
+            collections::hash_map::DefaultHasher,
+            hash::{Hash, Hasher},
+        };
+
         let mut hasher = DefaultHasher::new();
         round.hash(&mut hasher);
         record_store.pick_author(hasher.finish())
     }
 
-    fn duration(&self, record_store: &dyn RecordStore, round: Round) -> Duration {
+    fn duration(&self, record_store: &dyn RecordStore<Context>, round: Round) -> Duration {
         let highest_commit_certificate_round = if record_store.highest_committed_round() > Round(0)
         {
             record_store.highest_committed_round() + 2
@@ -119,7 +123,7 @@ impl PacemakerState {
     }
 }
 
-impl Default for PacemakerUpdateActions {
+impl<Context: SmrContext> Default for PacemakerUpdateActions<Context> {
     fn default() -> Self {
         PacemakerUpdateActions {
             next_scheduled_update: NodeTime::never(),
@@ -132,16 +136,16 @@ impl Default for PacemakerUpdateActions {
     }
 }
 
-impl Pacemaker for PacemakerState {
+impl<Context: SmrContext> Pacemaker<Context> for PacemakerState<Context> {
     // -- BEGIN FILE pacemaker_impl --
     fn update_pacemaker(
         &mut self,
-        local_author: Author,
+        local_author: Context::Author,
         epoch_id: EpochId,
-        record_store: &dyn RecordStore,
+        record_store: &dyn RecordStore<Context>,
         latest_query_all_time: NodeTime,
         clock: NodeTime,
-    ) -> PacemakerUpdateActions {
+    ) -> PacemakerUpdateActions<Context> {
         // Initialize actions with default values.
         let mut actions = PacemakerUpdateActions::default();
         // Compute the active round from the current record store.
@@ -210,7 +214,7 @@ impl Pacemaker for PacemakerState {
         self.active_round
     }
 
-    fn active_leader(&self) -> Option<Author> {
+    fn active_leader(&self) -> Option<Context::Author> {
         self.active_leader
     }
 }

--- a/librabft-v2/src/record.rs
+++ b/librabft-v2/src/record.rs
@@ -23,7 +23,7 @@ mod record_tests;
 // -- BEGIN FILE records --
 /// A record read from the network.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Hash)]
-pub enum Record {
+pub(crate) enum Record {
     /// Proposed block, containing a command, e.g. a set of Libra transactions.
     Block(Block),
     /// A single vote on a proposed block and its execution state.
@@ -35,73 +35,73 @@ pub enum Record {
 }
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
-pub struct Block {
+pub(crate) struct Block {
     /// User-defined command to execute in the state machine.
-    pub command: Command,
+    pub(crate) command: Command,
     /// Time proposed for command execution.
-    pub time: NodeTime,
+    pub(crate) time: NodeTime,
     /// Hash of the quorum certificate of the previous block.
-    pub previous_quorum_certificate_hash: QuorumCertificateHash,
+    pub(crate) previous_quorum_certificate_hash: QuorumCertificateHash,
     /// Number used to identify repeated attempts to propose a block.
-    pub round: Round,
+    pub(crate) round: Round,
     /// Creator of the block.
-    pub author: Author,
+    pub(crate) author: Author,
     /// Signs the hash of the block, that is, all the fields above.
-    pub signature: Signature,
+    pub(crate) signature: Signature,
 }
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
-pub struct Vote {
+pub(crate) struct Vote {
     /// The current epoch.
-    pub epoch_id: EpochId,
+    pub(crate) epoch_id: EpochId,
     /// The round of the voted block.
-    pub round: Round,
+    pub(crate) round: Round,
     /// Hash of the certified block.
-    pub certified_block_hash: BlockHash,
+    pub(crate) certified_block_hash: BlockHash,
     /// Execution state.
-    pub state: State,
+    pub(crate) state: State,
     /// Execution state of the ancestor block (if any) that will match
     /// the commit rule when a QC is formed at this round.
-    pub committed_state: Option<State>,
+    pub(crate) committed_state: Option<State>,
     /// Creator of the vote.
-    pub author: Author,
+    pub(crate) author: Author,
     /// Signs the hash of the vote, that is, all the fields above.
-    pub signature: Signature,
+    pub(crate) signature: Signature,
 }
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
 pub struct QuorumCertificate {
     /// The current epoch.
-    pub epoch_id: EpochId,
+    pub(crate) epoch_id: EpochId,
     /// The round of the certified block.
-    pub round: Round,
+    pub(crate) round: Round,
     /// Hash of the certified block.
-    pub certified_block_hash: BlockHash,
+    pub(crate) certified_block_hash: BlockHash,
     /// Execution state
-    pub state: State,
+    pub(crate) state: State,
     /// Execution state of the ancestor block (if any) that matches
     /// the commit rule thanks to this QC.
-    pub committed_state: Option<State>,
+    pub(crate) committed_state: Option<State>,
     /// A collections of votes sharing the fields above.
-    pub votes: Vec<(Author, Signature)>,
+    pub(crate) votes: Vec<(Author, Signature)>,
     /// The leader who proposed the certified block should also sign the QC.
-    pub author: Author,
+    pub(crate) author: Author,
     /// Signs the hash of the QC, that is, all the fields above.
-    pub signature: Signature,
+    pub(crate) signature: Signature,
 }
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
-pub struct Timeout {
+pub(crate) struct Timeout {
     /// The current epoch.
-    pub epoch_id: EpochId,
+    pub(crate) epoch_id: EpochId,
     /// The round that has timed out.
-    pub round: Round,
+    pub(crate) round: Round,
     /// Round of the highest block with a quorum certificate.
-    pub highest_certified_block_round: Round,
+    pub(crate) highest_certified_block_round: Round,
     /// Creator of the timeout object.
-    pub author: Author,
+    pub(crate) author: Author,
     /// Signs the hash of the timeout, that is, all the fields above.
-    pub signature: Signature,
+    pub(crate) signature: Signature,
 }
 // -- END FILE --
 
@@ -112,6 +112,7 @@ impl bft_lib::simulated_context::CommitCertificate for QuorumCertificate {
     }
 }
 
+// TODO: Use serde + BCS instead of Hash.
 impl Hash for Block {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.command.hash(state);
@@ -154,13 +155,13 @@ impl Hash for Timeout {
 }
 
 impl Record {
-    pub fn digest(&self) -> u64 {
+    pub(crate) fn digest(&self) -> u64 {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
         hasher.finish()
     }
 
-    pub fn make_block(
+    pub(crate) fn make_block(
         command: Command,
         time: NodeTime,
         previous_quorum_certificate_hash: QuorumCertificateHash,
@@ -183,7 +184,7 @@ impl Record {
         value
     }
 
-    pub fn make_vote(
+    pub(crate) fn make_vote(
         epoch_id: EpochId,
         round: Round,
         certified_block_hash: BlockHash,
@@ -208,7 +209,7 @@ impl Record {
         value
     }
 
-    pub fn make_timeout(
+    pub(crate) fn make_timeout(
         epoch_id: EpochId,
         round: Round,
         highest_certified_block_round: Round,
@@ -229,7 +230,7 @@ impl Record {
         value
     }
 
-    pub fn make_quorum_certificate(
+    pub(crate) fn make_quorum_certificate(
         epoch_id: EpochId,
         round: Round,
         certified_block_hash: BlockHash,
@@ -257,7 +258,7 @@ impl Record {
     }
 
     #[cfg(test)]
-    pub fn author(&self) -> Author {
+    pub(crate) fn author(&self) -> Author {
         match self {
             Record::Block(x) => x.author,
             Record::Vote(x) => x.author,
@@ -267,7 +268,7 @@ impl Record {
     }
 
     #[cfg(test)]
-    pub fn signature(&self) -> Signature {
+    pub(crate) fn signature(&self) -> Signature {
         match self {
             Record::Block(x) => x.signature,
             Record::Vote(x) => x.signature,

--- a/librabft-v2/src/record.rs
+++ b/librabft-v2/src/record.rs
@@ -3,95 +3,97 @@
 
 // We only use comparison for testing.
 #![allow(clippy::derive_hash_xor_eq)]
+#![allow(clippy::too_many_arguments)]
 
 use crate::base_types::*;
-use bft_lib::base_types::*;
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-};
+use bft_lib::{base_types::*, smr_context::SmrContext};
+use serde::{Deserialize, Serialize};
 
-#[cfg(test)]
+#[cfg(all(test, feature = "simulator"))]
 #[path = "unit_tests/record_tests.rs"]
 mod record_tests;
 
-// The following comments are used for code-block generation in the consensus report:
-//    "// -- BEGIN FILE name --"
-//    "// -- END FILE --"
-// DO NOT MODIFY definitions without changing the report as well :)
-
 // -- BEGIN FILE records --
 /// A record read from the network.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Hash)]
-pub(crate) enum Record {
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+pub(crate) enum Record<Context: SmrContext> {
     /// Proposed block, containing a command, e.g. a set of Libra transactions.
-    Block(Block),
+    #[serde(bound(deserialize = "Block<Context>: Deserialize<'de>"))]
+    Block(Block<Context>),
     /// A single vote on a proposed block and its execution state.
-    Vote(Vote),
+    #[serde(bound(deserialize = "Vote<Context>: Deserialize<'de>"))]
+    Vote(Vote<Context>),
     /// A quorum of votes related to a given block and execution state.
-    QuorumCertificate(QuorumCertificate),
+    #[serde(bound(deserialize = "QuorumCertificate<Context>: Deserialize<'de>"))]
+    QuorumCertificate(QuorumCertificate<Context>),
     /// A signal that a particular round of an epoch has reached a timeout.
-    Timeout(Timeout),
+    #[serde(bound(deserialize = "Timeout<Context>: Deserialize<'de>"))]
+    Timeout(Timeout<Context>),
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
-pub(crate) struct Block {
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct Block<Context: SmrContext> {
     /// User-defined command to execute in the state machine.
-    pub(crate) command: Command,
+    pub(crate) command: Context::Command,
     /// Time proposed for command execution.
     pub(crate) time: NodeTime,
     /// Hash of the quorum certificate of the previous block.
-    pub(crate) previous_quorum_certificate_hash: QuorumCertificateHash,
+    pub(crate) previous_quorum_certificate_hash: QuorumCertificateHash<Context::HashValue>,
     /// Number used to identify repeated attempts to propose a block.
     pub(crate) round: Round,
     /// Creator of the block.
-    pub(crate) author: Author,
+    pub(crate) author: Context::Author,
     /// Signs the hash of the block, that is, all the fields above.
-    pub(crate) signature: Signature,
+    #[serde(skip)]
+    // FIX ME: Here and below we use serde traits for hashing/signing. Because we skip this field,
+    // data are no longer serializable for networking purpose.
+    pub(crate) signature: Context::Signature,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
-pub(crate) struct Vote {
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct Vote<Context: SmrContext> {
     /// The current epoch.
     pub(crate) epoch_id: EpochId,
     /// The round of the voted block.
     pub(crate) round: Round,
     /// Hash of the certified block.
-    pub(crate) certified_block_hash: BlockHash,
+    pub(crate) certified_block_hash: BlockHash<Context::HashValue>,
     /// Execution state.
-    pub(crate) state: State,
+    pub(crate) state: Context::State,
     /// Execution state of the ancestor block (if any) that will match
     /// the commit rule when a QC is formed at this round.
-    pub(crate) committed_state: Option<State>,
+    pub(crate) committed_state: Option<Context::State>,
     /// Creator of the vote.
-    pub(crate) author: Author,
+    pub(crate) author: Context::Author,
     /// Signs the hash of the vote, that is, all the fields above.
-    pub(crate) signature: Signature,
+    #[serde(skip)]
+    pub(crate) signature: Context::Signature,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
-pub struct QuorumCertificate {
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+pub struct QuorumCertificate<Context: SmrContext> {
     /// The current epoch.
     pub(crate) epoch_id: EpochId,
     /// The round of the certified block.
     pub(crate) round: Round,
     /// Hash of the certified block.
-    pub(crate) certified_block_hash: BlockHash,
+    pub(crate) certified_block_hash: BlockHash<Context::HashValue>,
     /// Execution state
-    pub(crate) state: State,
+    pub(crate) state: Context::State,
     /// Execution state of the ancestor block (if any) that matches
     /// the commit rule thanks to this QC.
-    pub(crate) committed_state: Option<State>,
+    pub(crate) committed_state: Option<Context::State>,
     /// A collections of votes sharing the fields above.
-    pub(crate) votes: Vec<(Author, Signature)>,
+    pub(crate) votes: Vec<(Context::Author, Context::Signature)>,
     /// The leader who proposed the certified block should also sign the QC.
-    pub(crate) author: Author,
+    pub(crate) author: Context::Author,
     /// Signs the hash of the QC, that is, all the fields above.
-    pub(crate) signature: Signature,
+    #[serde(skip)]
+    pub(crate) signature: Context::Signature,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
-pub(crate) struct Timeout {
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct Timeout<Context: SmrContext> {
     /// The current epoch.
     pub(crate) epoch_id: EpochId,
     /// The round that has timed out.
@@ -99,146 +101,110 @@ pub(crate) struct Timeout {
     /// Round of the highest block with a quorum certificate.
     pub(crate) highest_certified_block_round: Round,
     /// Creator of the timeout object.
-    pub(crate) author: Author,
+    pub(crate) author: Context::Author,
     /// Signs the hash of the timeout, that is, all the fields above.
-    pub(crate) signature: Signature,
+    #[serde(skip)]
+    pub(crate) signature: Context::Signature,
 }
 // -- END FILE --
 
-#[cfg(feature = "simulator")]
-impl bft_lib::simulated_context::CommitCertificate for QuorumCertificate {
-    fn committed_state(&self) -> Option<&State> {
+impl<Context: SmrContext> bft_lib::smr_context::CommitCertificate<Context::State>
+    for QuorumCertificate<Context>
+{
+    fn committed_state(&self) -> Option<&Context::State> {
         self.committed_state.as_ref()
     }
 }
 
-// TODO: Use serde + BCS instead of Hash.
-impl Hash for Block {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.command.hash(state);
-        self.time.hash(state);
-        self.previous_quorum_certificate_hash.hash(state);
-        self.round.hash(state);
-        self.author.hash(state);
-    }
-}
-
-impl Hash for Vote {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.epoch_id.hash(state);
-        self.round.hash(state);
-        self.certified_block_hash.hash(state);
-        self.state.hash(state);
-        self.committed_state.hash(state);
-        self.author.hash(state);
-    }
-}
-
-impl Hash for QuorumCertificate {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.epoch_id.hash(state);
-        self.round.hash(state);
-        self.certified_block_hash.hash(state);
-        self.state.hash(state);
-        self.committed_state.hash(state);
-        self.votes.hash(state);
-        self.author.hash(state);
-    }
-}
-
-impl Hash for Timeout {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.epoch_id.hash(state);
-        self.round.hash(state);
-        self.author.hash(state);
-    }
-}
-
-impl Record {
-    pub(crate) fn digest(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        hasher.finish()
-    }
-
+impl<Context: SmrContext> Record<Context> {
     pub(crate) fn make_block(
-        command: Command,
+        context: &mut Context,
+        command: Context::Command,
         time: NodeTime,
-        previous_quorum_certificate_hash: QuorumCertificateHash,
+        previous_quorum_certificate_hash: QuorumCertificateHash<Context::HashValue>,
         round: Round,
-        author: Author,
-    ) -> Record {
+        author: Context::Author,
+    ) -> Record<Context> {
         let mut value = Record::Block(Block {
             command,
             time,
             previous_quorum_certificate_hash,
             round,
             author,
-            signature: Signature(0),
+            signature: Context::Signature::default(),
         });
-        let hash = value.digest();
+        assert_eq!(&author, context.author());
+        let h = context.hash(&value);
+        let s = context.sign(h).expect("Signing should not fail");
         match &mut value {
-            Record::Block(block) => block.signature = Signature::sign(hash, block.author),
+            Record::Block(block) => block.signature = s,
             _ => unreachable!(),
         }
         value
     }
 
     pub(crate) fn make_vote(
+        context: &mut Context,
         epoch_id: EpochId,
         round: Round,
-        certified_block_hash: BlockHash,
-        state: State,
-        author: Author,
-        committed_state: Option<State>,
-    ) -> Record {
+        certified_block_hash: BlockHash<Context::HashValue>,
+        state: Context::State,
+        author: Context::Author,
+        committed_state: Option<Context::State>,
+    ) -> Record<Context> {
         let mut value = Record::Vote(Vote {
             epoch_id,
             round,
             certified_block_hash,
             state,
             author,
-            signature: Signature(0),
+            signature: Context::Signature::default(),
             committed_state,
         });
-        let hash = value.digest();
+        assert_eq!(&author, context.author());
+        let h = context.hash(&value);
+        let s = context.sign(h).expect("Signing should not fail");
         match &mut value {
-            Record::Vote(vote) => vote.signature = Signature::sign(hash, vote.author),
+            Record::Vote(vote) => vote.signature = s,
             _ => unreachable!(),
         }
         value
     }
 
     pub(crate) fn make_timeout(
+        context: &mut Context,
         epoch_id: EpochId,
         round: Round,
         highest_certified_block_round: Round,
-        author: Author,
-    ) -> Record {
+        author: Context::Author,
+    ) -> Record<Context> {
         let mut value = Record::Timeout(Timeout {
             epoch_id,
             round,
             highest_certified_block_round,
             author,
-            signature: Signature(0),
+            signature: Context::Signature::default(),
         });
-        let hash = value.digest();
+        assert_eq!(&author, context.author());
+        let h = context.hash(&value);
+        let s = context.sign(h).expect("Signing should not fail");
         match &mut value {
-            Record::Timeout(timeout) => timeout.signature = Signature::sign(hash, timeout.author),
+            Record::Timeout(timeout) => timeout.signature = s,
             _ => unreachable!(),
         }
         value
     }
 
     pub(crate) fn make_quorum_certificate(
+        context: &mut Context,
         epoch_id: EpochId,
         round: Round,
-        certified_block_hash: BlockHash,
-        state: State,
-        votes: Vec<(Author, Signature)>,
-        committed_state: Option<State>,
-        author: Author,
-    ) -> Record {
+        certified_block_hash: BlockHash<Context::HashValue>,
+        state: Context::State,
+        votes: Vec<(Context::Author, Context::Signature)>,
+        committed_state: Option<Context::State>,
+        author: Context::Author,
+    ) -> Record<Context> {
         let mut value = Record::QuorumCertificate(QuorumCertificate {
             epoch_id,
             round,
@@ -247,18 +213,20 @@ impl Record {
             votes,
             committed_state,
             author,
-            signature: Signature(0),
+            signature: Context::Signature::default(),
         });
-        let hash = value.digest();
+        assert_eq!(&author, context.author());
+        let h = context.hash(&value);
+        let s = context.sign(h).expect("Signing should not fail");
         match &mut value {
-            Record::QuorumCertificate(qc) => qc.signature = Signature::sign(hash, qc.author),
+            Record::QuorumCertificate(qc) => qc.signature = s,
             _ => unreachable!(),
         }
         value
     }
 
-    #[cfg(test)]
-    pub(crate) fn author(&self) -> Author {
+    #[cfg(all(test, feature = "simulator"))]
+    pub(crate) fn author(&self) -> Context::Author {
         match self {
             Record::Block(x) => x.author,
             Record::Vote(x) => x.author,
@@ -267,8 +235,8 @@ impl Record {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn signature(&self) -> Signature {
+    #[cfg(all(test, feature = "simulator"))]
+    pub(crate) fn signature(&self) -> Context::Signature {
         match self {
             Record::Block(x) => x.signature,
             Record::Vote(x) => x.signature,

--- a/librabft-v2/src/record_store.rs
+++ b/librabft-v2/src/record_store.rs
@@ -19,7 +19,7 @@ use std::{
 mod record_store_tests;
 
 // -- BEGIN FILE record_store --
-pub trait RecordStore: Debug {
+pub(crate) trait RecordStore: Debug {
     /// Return the hash of a QC at the highest round, or the initial hash.
     fn highest_quorum_certificate_hash(&self) -> QuorumCertificateHash;
     /// Query the round of the highest QC.
@@ -169,7 +169,7 @@ impl<'a> Iterator for BackwardQuorumCertificateIterator<'a> {
 }
 
 impl RecordStoreState {
-    pub fn new(
+    pub(crate) fn new(
         initial_hash: QuorumCertificateHash,
         initial_state: State,
         epoch_id: EpochId,

--- a/librabft-v2/src/record_store.rs
+++ b/librabft-v2/src/record_store.rs
@@ -6,8 +6,8 @@ use crate::{
     pacemaker::{Pacemaker, PacemakerState},
     record::*,
 };
+use anyhow::{bail, ensure};
 use bft_lib::{base_types::*, configuration::EpochConfiguration, smr_context::SmrContext};
-use failure::{bail, ensure};
 use log::{debug, info, warn};
 use std::{
     collections::{BTreeSet, HashMap},

--- a/librabft-v2/src/record_store.rs
+++ b/librabft-v2/src/record_store.rs
@@ -6,7 +6,7 @@ use crate::{
     pacemaker::{Pacemaker, PacemakerState},
     record::*,
 };
-use bft_lib::{base_types::*, smr_context::SmrContext, EpochConfiguration};
+use bft_lib::{base_types::*, configuration::EpochConfiguration, smr_context::SmrContext};
 use failure::{bail, ensure};
 use log::{debug, info, warn};
 use std::{

--- a/librabft-v2/src/unit_tests/node_tests.rs
+++ b/librabft-v2/src/unit_tests/node_tests.rs
@@ -5,10 +5,6 @@ use super::*;
 use crate::base_types::BlockHash;
 use bft_lib::{simulated_context::*, smr_context, smr_context::*};
 use futures::executor::block_on;
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-};
 
 #[test]
 fn test_node() {
@@ -17,24 +13,30 @@ fn test_node() {
         /* num_nodes */ 1,
         /* max commands per epoch */ 2,
     );
-    let initial_hash = QuorumCertificateHash(0);
-    let initial_state = context.last_committed_state();
     let epoch_id = EpochId(0);
+    let initial_hash = QuorumCertificateHash(context.hash(&epoch_id));
+    let initial_state = context.last_committed_state();
     let mut node1 = block_on(NodeState::load_node(&mut context, NodeTime(0)));
 
     // Make a sequence of blocks / QCs
     let cmd = context.fetch().unwrap();
-    let b0 = Record::make_block(cmd.clone(), NodeTime(1), initial_hash, Round(1), Author(0));
+    let b0 = Record::make_block(
+        &mut context,
+        cmd.clone(),
+        NodeTime(1),
+        initial_hash,
+        Round(1),
+        Author(0),
+    );
 
-    let mut hasher = DefaultHasher::new();
-    b0.hash(&mut hasher);
-    let block_hash = BlockHash(hasher.finish());
+    let block_hash = BlockHash(context.hash(&b0));
 
     let state = context
         .compute(&initial_state, cmd, NodeTime(1), None, Vec::new())
         .unwrap();
 
     let v0 = match Record::make_vote(
+        &mut context,
         epoch_id,
         Round(1),
         block_hash,
@@ -46,6 +48,7 @@ fn test_node() {
         _ => unreachable!(),
     };
     let qc0 = Record::make_quorum_certificate(
+        &mut context,
         epoch_id,
         Round(1),
         block_hash,
@@ -54,7 +57,7 @@ fn test_node() {
         /* commitment */ None,
         Author(0),
     );
-    let qc_hash = QuorumCertificateHash(qc0.digest());
+    let qc_hash = QuorumCertificateHash(context.hash(&qc0));
 
     node1.insert_network_record(epoch_id, b0, &mut context);
     node1.insert_network_record(epoch_id, qc0, &mut context);

--- a/librabft-v2/src/unit_tests/record_store_tests.rs
+++ b/librabft-v2/src/unit_tests/record_store_tests.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use bft_lib::{simulated_context::SimulatedContext, smr_context::*};
+use bft_lib::{simulated_context::*, smr_context::*};
 
 struct SharedRecordStore {
-    store: RecordStoreState,
+    store: RecordStoreState<SimulatedContext>,
     contexts: HashMap<Author, SimulatedContext>,
 }
 
@@ -41,7 +41,7 @@ impl SharedRecordStore {
     fn propose_block(
         &mut self,
         author_id: usize,
-        previous_qc_hash: QuorumCertificateHash,
+        previous_qc_hash: QuorumCertificateHash<u64>,
         clock: NodeTime,
     ) {
         let author = Author(author_id);
@@ -53,7 +53,7 @@ impl SharedRecordStore {
         );
     }
 
-    fn create_vote(&mut self, author_id: usize, block_hash: BlockHash) -> bool {
+    fn create_vote(&mut self, author_id: usize, block_hash: BlockHash<u64>) -> bool {
         let author = Author(author_id);
         self.store
             .create_vote(author, block_hash, self.contexts.get_mut(&author).unwrap())


### PR DESCRIPTION
The mega trait `SmrContext` now includes a trait `CryptographicModule` which provides hashing and signing (and the corresponding data types).

While we're at it, I also made the notion of command and state generic.

The generic types are verbose but I find it personally very satisfying to be able to write unit test with simplistic types in the simulated world.