### PR TITLE
move LibraBFT-specific config out of bft-lib

### DIFF
--- a/bft-lib/src/unit_tests/simulated_context_tests.rs
+++ b/bft-lib/src/unit_tests/simulated_context_tests.rs
@@ -16,7 +16,8 @@ impl BcsSignable for Bar {}
 #[test]
 fn test_hashing_and_signing() {
     let mut context = SimulatedContext::new(
-        Config::new(Author(0)),
+        Author(0),
+        (),
         /* num_nodes */ 2,
         /* max commands per epoch */ 2,
     );
@@ -79,7 +80,8 @@ impl CommitCertificate<State> for DummyCertificate {
 #[test]
 fn test_simulated_context() {
     let mut context = SimulatedContext::new(
-        Config::new(Author(0)),
+        Author(0),
+        (),
         /* num_nodes */ 2,
         /* max commands per epoch */ 2,
     );

--- a/librabft-v2/src/data_sync.rs
+++ b/librabft-v2/src/data_sync.rs
@@ -48,7 +48,7 @@ pub struct DataSyncResponse<Context: SmrContext> {
 
 impl<Context> NodeState<Context>
 where
-    Context: SmrContext<Config = Config>,
+    Context: SmrContext<Config = NodeConfig>,
 {
     fn create_request_internal(&self) -> DataSyncRequest {
         DataSyncRequest {
@@ -60,7 +60,7 @@ where
 
 impl<Context> DataSyncNode<Context> for NodeState<Context>
 where
-    Context: SmrContext<Config = Config>,
+    Context: SmrContext<Config = NodeConfig>,
 {
     type Notification = DataSyncNotification<Context>;
     type Request = DataSyncRequest;

--- a/librabft-v2/src/data_sync.rs
+++ b/librabft-v2/src/data_sync.rs
@@ -46,7 +46,10 @@ pub struct DataSyncResponse<Context: SmrContext> {
 }
 // -- END FILE --
 
-impl<Context: SmrContext> NodeState<Context> {
+impl<Context> NodeState<Context>
+where
+    Context: SmrContext<Config = Config>,
+{
     fn create_request_internal(&self) -> DataSyncRequest {
         DataSyncRequest {
             current_epoch: self.epoch_id(),
@@ -55,7 +58,10 @@ impl<Context: SmrContext> NodeState<Context> {
     }
 }
 
-impl<Context: SmrContext> DataSyncNode<Context> for NodeState<Context> {
+impl<Context> DataSyncNode<Context> for NodeState<Context>
+where
+    Context: SmrContext<Config = Config>,
+{
     type Notification = DataSyncNotification<Context>;
     type Request = DataSyncRequest;
     type Response = DataSyncResponse<Context>;

--- a/librabft-v2/src/main.rs
+++ b/librabft-v2/src/main.rs
@@ -7,16 +7,18 @@ use bft_lib::{base_types::*, simulated_context::SimulatedContext, simulator};
 use clap::{App, Arg};
 use librabft_v2::{
     data_sync::*,
-    node::{Config, NodeState},
+    node::{NodeConfig, NodeState},
 };
 use log::{info, warn};
+
+type Context = SimulatedContext<NodeConfig>;
 
 fn main() {
     let args = get_arguments();
 
     env_logger::init();
     let context_factory = |author, num_nodes| {
-        let config = Config {
+        let config = NodeConfig {
             target_commit_interval: args.target_commit_interval,
             delta: args.delta,
             gamma: args.gamma,
@@ -26,11 +28,11 @@ fn main() {
     };
     let delay_distribution = simulator::RandomDelay::new(args.mean, args.variance);
     let mut sim = simulator::Simulator::<
-        NodeState<SimulatedContext<Config>>,
-        SimulatedContext<Config>,
-        DataSyncNotification<SimulatedContext<Config>>,
+        NodeState<Context>,
+        Context,
+        DataSyncNotification<Context>,
         DataSyncRequest,
-        DataSyncResponse<SimulatedContext<Config>>,
+        DataSyncResponse<Context>,
     >::new(args.nodes, delay_distribution, context_factory);
     let contexts = sim.loop_until(
         simulator::GlobalTime(args.max_clock),

--- a/librabft-v2/src/node.rs
+++ b/librabft-v2/src/node.rs
@@ -73,7 +73,7 @@ impl CommitTracker {
 // Persistent configuration.
 #[derive(PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Default))]
-pub struct Config {
+pub struct NodeConfig {
     pub target_commit_interval: Duration,
     pub delta: Duration,
     pub gamma: f64,
@@ -82,11 +82,11 @@ pub struct Config {
 
 impl<Context> NodeState<Context>
 where
-    Context: SmrContext<Config = Config>,
+    Context: SmrContext<Config = NodeConfig>,
 {
     fn new(
         author: Context::Author,
-        config: Config,
+        config: NodeConfig,
         initial_state: Context::State,
         node_time: NodeTime,
         context: &Context,
@@ -213,7 +213,7 @@ impl<Context: SmrContext> NodeState<Context> {
 // -- BEGIN FILE consensus_node_impl --
 impl<Context> ConsensusNode<Context> for NodeState<Context>
 where
-    Context: SmrContext<Config = Config>,
+    Context: SmrContext<Config = NodeConfig>,
 {
     fn load_node(context: &mut Context, node_time: NodeTime) -> AsyncResult<Self> {
         let author = context.author();
@@ -299,7 +299,7 @@ where
 // -- BEGIN FILE process_commits --
 impl<Context> NodeState<Context>
 where
-    Context: SmrContext<Config = Config>,
+    Context: SmrContext<Config = NodeConfig>,
 {
     pub(crate) fn process_commits(&mut self, context: &mut Context) {
         // For all commits that have not been processed yet, according to the commit tracker..

--- a/librabft-v2/src/node.rs
+++ b/librabft-v2/src/node.rs
@@ -7,11 +7,11 @@ use crate::{pacemaker::*, record::*, record_store::*};
 use bft_lib::{
     base_types::*,
     interfaces::{ConsensusNode, NodeUpdateActions},
-    smr_context,
     smr_context::SmrContext,
 };
 use futures::future;
 use log::debug;
+use serde::{Deserialize, Serialize};
 use std::{
     cmp::{max, min},
     collections::HashMap,
@@ -70,12 +70,23 @@ impl CommitTracker {
     }
 }
 
+// Persistent configuration.
+#[derive(PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Default))]
+pub struct Config {
+    pub target_commit_interval: Duration,
+    pub delta: Duration,
+    pub gamma: f64,
+    pub lambda: f64,
+}
+
 impl<Context> NodeState<Context>
 where
-    Context: SmrContext,
+    Context: SmrContext<Config = Config>,
 {
     fn new(
-        config: smr_context::Config<Context::Author>,
+        author: Context::Author,
+        config: Config,
         initial_state: Context::State,
         node_time: NodeTime,
         context: &Context,
@@ -98,7 +109,7 @@ where
                 config.lambda,
             ),
             epoch_id,
-            local_author: config.author,
+            local_author: author,
             latest_voted_round: Round(0),
             locked_round: Round(0),
             latest_query_all_time: node_time,
@@ -202,12 +213,13 @@ impl<Context: SmrContext> NodeState<Context> {
 // -- BEGIN FILE consensus_node_impl --
 impl<Context> ConsensusNode<Context> for NodeState<Context>
 where
-    Context: SmrContext,
+    Context: SmrContext<Config = Config>,
 {
     fn load_node(context: &mut Context, node_time: NodeTime) -> AsyncResult<Self> {
+        let author = context.author();
         let config = context.config().clone();
         let state = context.state();
-        let node = NodeState::new(config, state, node_time, &*context);
+        let node = NodeState::new(author, config, state, node_time, &*context);
         Box::new(future::ready(node))
     }
 
@@ -287,7 +299,7 @@ where
 // -- BEGIN FILE process_commits --
 impl<Context> NodeState<Context>
 where
-    Context: SmrContext,
+    Context: SmrContext<Config = Config>,
 {
     pub(crate) fn process_commits(&mut self, context: &mut Context) {
         // For all commits that have not been processed yet, according to the commit tracker..

--- a/librabft-v2/src/unit_tests/node_tests.rs
+++ b/librabft-v2/src/unit_tests/node_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::{node::Config, record::BlockHash};
+use crate::{node::NodeConfig, record::BlockHash};
 use bft_lib::{simulated_context::*, smr_context::*};
 use futures::executor::block_on;
 
@@ -10,7 +10,7 @@ use futures::executor::block_on;
 fn test_node() {
     let mut context = SimulatedContext::new(
         Author(0),
-        Config::default(),
+        NodeConfig::default(),
         /* num_nodes */ 1,
         /* max commands per epoch */ 2,
     );
@@ -40,7 +40,7 @@ fn test_node() {
 
     let v0 = SignedValue::make(
         &mut context,
-        Vote_::<SimulatedContext<Config>> {
+        Vote_::<SimulatedContext<NodeConfig>> {
             epoch_id,
             round: Round(1),
             certified_block_hash: block_hash,

--- a/librabft-v2/src/unit_tests/node_tests.rs
+++ b/librabft-v2/src/unit_tests/node_tests.rs
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::record::BlockHash;
-use bft_lib::{simulated_context::*, smr_context, smr_context::*};
+use crate::{node::Config, record::BlockHash};
+use bft_lib::{simulated_context::*, smr_context::*};
 use futures::executor::block_on;
 
 #[test]
 fn test_node() {
     let mut context = SimulatedContext::new(
-        smr_context::Config::new(Author(0)),
+        Author(0),
+        Config::default(),
         /* num_nodes */ 1,
         /* max commands per epoch */ 2,
     );
@@ -39,7 +40,7 @@ fn test_node() {
 
     let v0 = SignedValue::make(
         &mut context,
-        Vote_::<SimulatedContext> {
+        Vote_::<SimulatedContext<Config>> {
             epoch_id,
             round: Round(1),
             certified_block_hash: block_hash,

--- a/librabft-v2/src/unit_tests/record_store_tests.rs
+++ b/librabft-v2/src/unit_tests/record_store_tests.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::node::Config;
 use bft_lib::{simulated_context::*, smr_context::*};
 
 struct SharedRecordStore {
-    store: RecordStoreState<SimulatedContext>,
-    contexts: HashMap<Author, SimulatedContext>,
+    store: RecordStoreState<SimulatedContext<Config>>,
+    contexts: HashMap<Author, SimulatedContext<Config>>,
 }
 
 impl SharedRecordStore {
@@ -17,7 +18,7 @@ impl SharedRecordStore {
         for i in 0..num_nodes {
             contexts.insert(
                 Author(i),
-                SimulatedContext::new(Config::new(Author(i)), num_nodes, epoch_ttl),
+                SimulatedContext::new(Author(i), Config::default(), num_nodes, epoch_ttl),
             );
         }
         let state = contexts.get(&Author(0)).unwrap().last_committed_state();

--- a/librabft-v2/src/unit_tests/record_store_tests.rs
+++ b/librabft-v2/src/unit_tests/record_store_tests.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::node::Config;
+use crate::node::NodeConfig;
 use bft_lib::{simulated_context::*, smr_context::*};
 
 struct SharedRecordStore {
-    store: RecordStoreState<SimulatedContext<Config>>,
-    contexts: HashMap<Author, SimulatedContext<Config>>,
+    store: RecordStoreState<SimulatedContext<NodeConfig>>,
+    contexts: HashMap<Author, SimulatedContext<NodeConfig>>,
 }
 
 impl SharedRecordStore {
@@ -18,7 +18,7 @@ impl SharedRecordStore {
         for i in 0..num_nodes {
             contexts.insert(
                 Author(i),
-                SimulatedContext::new(Author(i), Config::default(), num_nodes, epoch_ttl),
+                SimulatedContext::new(Author(i), NodeConfig::default(), num_nodes, epoch_ttl),
             );
         }
         let state = contexts.get(&Author(0)).unwrap().last_committed_state();

--- a/librabft-v2/src/unit_tests/record_tests.rs
+++ b/librabft-v2/src/unit_tests/record_tests.rs
@@ -2,20 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::node::Config;
+use crate::node::NodeConfig;
 use bft_lib::{simulated_context::*, smr_context::CryptographicModule};
 
 #[test]
 fn test_block_signing() {
     let mut context = SimulatedContext::new(
         Author(2),
-        Config::default(),
+        NodeConfig::default(),
         /* not used */ 0,
         /* not used */ 0,
     );
     let b = SignedValue::make(
         &mut context,
-        Block_::<SimulatedContext<Config>> {
+        Block_::<SimulatedContext<NodeConfig>> {
             command: Command {
                 proposer: Author(1),
                 index: 2,
@@ -33,7 +33,7 @@ fn test_block_signing() {
 
     let b2 = SignedValue::make(
         &mut context,
-        Block_::<SimulatedContext<Config>> {
+        Block_::<SimulatedContext<NodeConfig>> {
             command: Command {
                 proposer: Author(3),
                 index: 2,

--- a/librabft-v2/src/unit_tests/record_tests.rs
+++ b/librabft-v2/src/unit_tests/record_tests.rs
@@ -2,21 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use bft_lib::{
-    simulated_context::*,
-    smr_context::{Config, CryptographicModule},
-};
+use crate::node::Config;
+use bft_lib::{simulated_context::*, smr_context::CryptographicModule};
 
 #[test]
 fn test_block_signing() {
     let mut context = SimulatedContext::new(
-        Config::new(Author(2)),
+        Author(2),
+        Config::default(),
         /* not used */ 0,
         /* not used */ 0,
     );
     let b = SignedValue::make(
         &mut context,
-        Block_::<SimulatedContext> {
+        Block_::<SimulatedContext<Config>> {
             command: Command {
                 proposer: Author(1),
                 index: 2,
@@ -34,7 +33,7 @@ fn test_block_signing() {
 
     let b2 = SignedValue::make(
         &mut context,
-        Block_::<SimulatedContext> {
+        Block_::<SimulatedContext<Config>> {
             command: Command {
                 proposer: Author(3),
                 index: 2,


### PR DESCRIPTION
Create a type parameter `Config` that can be specified by each protocol implementation.
Make `SimulatedContext` generic w.r.t. `Config`.