### PR TITLE
[librabftv2] add missing serialization traits to DataSync*

### DIFF
--- a/bft-lib/src/smr_context.rs
+++ b/bft-lib/src/smr_context.rs
@@ -200,7 +200,7 @@ pub trait SmrContext:
     // https://github.com/rust-lang/rust/issues/26925 ). The real fix
     // is to implement traits manually in librabft_v2/record.rs (and
     // probably in other places).
-    + Eq + PartialEq + Ord + PartialOrd + Clone + Debug + serde::Serialize + serde::de::DeserializeOwned + 'static
+    + Eq + PartialEq + Ord + PartialOrd + Clone + Debug + 'static
 {
 }
 // -- END FILE --

--- a/librabft-v2/Cargo.toml
+++ b/librabft-v2/Cargo.toml
@@ -23,6 +23,9 @@ serde = { version = "1.0", features = ["derive"] }
 
 bft-lib = { path = "../bft-lib" }
 
+[dev-dependencies]
+serde_json = "1.0"
+
 [[bin]]
 name = "librabft_simulator"
 required-features = ["simulator"]

--- a/librabft-v2/src/data_sync.rs
+++ b/librabft-v2/src/data_sync.rs
@@ -4,30 +4,41 @@
 use crate::{node::*, record::*};
 use bft_lib::{base_types::*, interfaces::DataSyncNode, smr_context::SmrContext};
 use futures::future;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "simulator"))]
 #[path = "unit_tests/data_sync_tests.rs"]
 mod data_sync_tests;
 
 // -- BEGIN FILE data_sync --
-#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Serialize, Deserialize)]
 pub struct DataSyncNotification<Context: SmrContext> {
     /// Current epoch identifier.
     current_epoch: EpochId,
     /// Tail QC of the highest commit rule.
+    #[serde(bound(serialize = "Context: SmrContext"))]
+    #[serde(bound(deserialize = "Context: SmrContext"))]
     highest_commit_certificate: Option<QuorumCertificate<Context>>,
     /// Highest QC.
+    #[serde(bound(serialize = "Context: SmrContext"))]
+    #[serde(bound(deserialize = "Context: SmrContext"))]
     highest_quorum_certificate: Option<QuorumCertificate<Context>>,
     /// Timeouts in the highest TC, then at the current round, if any.
+    #[serde(bound(serialize = "Context: SmrContext"))]
+    #[serde(bound(deserialize = "Context: SmrContext"))]
     timeouts: Vec<Timeout<Context>>,
     /// Sender's vote at the current round, if any (meant for the proposer).
+    #[serde(bound(serialize = "Context: SmrContext"))]
+    #[serde(bound(deserialize = "Context: SmrContext"))]
     current_vote: Option<Vote<Context>>,
     /// Known proposed block at the current round, if any.
+    #[serde(bound(serialize = "Context: SmrContext"))]
+    #[serde(bound(deserialize = "Context: SmrContext"))]
     proposed_block: Option<Block<Context>>,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Serialize, Deserialize)]
 pub struct DataSyncRequest {
     /// Current epoch identifier.
     current_epoch: EpochId,
@@ -35,13 +46,15 @@ pub struct DataSyncRequest {
     known_quorum_certificates: BTreeSet<Round>,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct DataSyncResponse<Context: SmrContext> {
     /// Current epoch identifier.
     current_epoch: EpochId,
     /// Records for the receiver to insert, for each epoch, in the given order.
     /// Epochs older than the receiver's current epoch will be skipped, as well as chains
     /// of records ending with QC known to the receiver.
+    #[serde(bound(serialize = "Context: SmrContext"))]
+    #[serde(bound(deserialize = "Context: SmrContext"))]
     records: Vec<(EpochId, Vec<Record<Context>>)>,
 }
 // -- END FILE --

--- a/librabft-v2/src/record.rs
+++ b/librabft-v2/src/record.rs
@@ -16,16 +16,20 @@ mod record_tests;
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub(crate) enum Record<Context: SmrContext> {
     /// Proposed block, containing a command, e.g. a set of Libra transactions.
-    #[serde(bound(deserialize = "Block<Context>: Deserialize<'de>"))]
+    #[serde(bound(serialize = "Context: SmrContext"))]
+    #[serde(bound(deserialize = "Context: SmrContext"))]
     Block(Block<Context>),
     /// A single vote on a proposed block and its execution state.
-    #[serde(bound(deserialize = "Vote<Context>: Deserialize<'de>"))]
+    #[serde(bound(serialize = "Context: SmrContext"))]
+    #[serde(bound(deserialize = "Context: SmrContext"))]
     Vote(Vote<Context>),
     /// A quorum of votes related to a given block and execution state.
-    #[serde(bound(deserialize = "QuorumCertificate<Context>: Deserialize<'de>"))]
+    #[serde(bound(serialize = "Context: SmrContext"))]
+    #[serde(bound(deserialize = "Context: SmrContext"))]
     QuorumCertificate(QuorumCertificate<Context>),
     /// A signal that a particular round of an epoch has reached a timeout.
-    #[serde(bound(deserialize = "Timeout<Context>: Deserialize<'de>"))]
+    #[serde(bound(serialize = "Context: SmrContext"))]
+    #[serde(bound(deserialize = "Context: SmrContext"))]
     Timeout(Timeout<Context>),
 }
 

--- a/librabft-v2/src/unit_tests/data_sync_tests.rs
+++ b/librabft-v2/src/unit_tests/data_sync_tests.rs
@@ -1,2 +1,47 @@
 // Copyright (c) Calibra Research
 // SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::node::NodeConfig;
+use bft_lib::simulated_context::SimulatedContext;
+use serde_json;
+use std::collections::BTreeSet;
+
+#[test]
+fn test_serde_notification() {
+    let data = DataSyncNotification::<SimulatedContext<NodeConfig>> {
+        current_epoch: EpochId(0),
+        highest_commit_certificate: None,
+        highest_quorum_certificate: None,
+        timeouts: Vec::new(),
+        current_vote: None,
+        proposed_block: None,
+    };
+    let message = serde_json::to_string(&data).unwrap();
+    let data2: DataSyncNotification<SimulatedContext<NodeConfig>> =
+        serde_json::from_str(&message).unwrap();
+    assert_eq!(data2, data);
+}
+
+#[test]
+fn test_serde_request() {
+    let data = DataSyncRequest {
+        current_epoch: EpochId(0),
+        known_quorum_certificates: BTreeSet::default(),
+    };
+    let message = serde_json::to_string(&data).unwrap();
+    let data2: DataSyncRequest = serde_json::from_str(&message).unwrap();
+    assert_eq!(data2, data);
+}
+
+#[test]
+fn test_serde_response() {
+    let data = DataSyncResponse::<SimulatedContext<NodeConfig>> {
+        current_epoch: EpochId(0),
+        records: Vec::new(),
+    };
+    let message = serde_json::to_string(&data).unwrap();
+    let data2: DataSyncResponse<SimulatedContext<NodeConfig>> =
+        serde_json::from_str(&message).unwrap();
+    assert_eq!(data2, data);
+}


### PR DESCRIPTION
Make sure that we can (de)serialize network messages in the LibraBFTv2 specs.