### PR TITLE
Make simulator deterministic + Simplify trait bounds

### DIFF
--- a/bft-lib/Cargo.toml
+++ b/bft-lib/Cargo.toml
@@ -15,8 +15,10 @@ simulator = []
 env_logger = "0.8.1"
 anyhow = "1.0"
 log = "0.4.6"
-rand = "0.7.3"
-rand_distr = "0.3.0"
+rand = { version = "0.8.3" }
+rand_core = "0.6.0"
+rand_distr = "0.4.0"
+rand_xoshiro = "0.6.0"
 clap = "2.33"
 csv = "1.1"
 bcs = "0.1.2"

--- a/bft-lib/src/simulated_context.rs
+++ b/bft-lib/src/simulated_context.rs
@@ -6,7 +6,7 @@ use anyhow::ensure;
 use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeMap, HashMap},
+    collections::{hash_map::DefaultHasher, HashMap},
     fmt::Debug,
     hash::{Hash, Hasher},
 };
@@ -15,7 +15,7 @@ use std::{
 #[path = "unit_tests/simulated_context_tests.rs"]
 mod simulated_context_tests;
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
 pub struct Author(pub usize);
 
 #[derive(Eq, PartialEq, Copy, Clone, Hash, Debug, Serialize, Deserialize, Default)]
@@ -212,9 +212,9 @@ impl<Config> EpochReader<Author, State> for SimulatedContext<Config> {
 
     fn configuration(&self, _state: &State) -> EpochConfiguration<Author> {
         // We do not simulate changes in the voting rights yet.
-        let mut voting_rights = BTreeMap::new();
+        let mut voting_rights = Vec::new();
         for index in 0..self.num_nodes {
-            voting_rights.insert(Author(index), 1);
+            voting_rights.push((Author(index), 1));
         }
         EpochConfiguration::new(voting_rights)
     }

--- a/bft-lib/src/simulated_context.rs
+++ b/bft-lib/src/simulated_context.rs
@@ -17,16 +17,17 @@ mod simulated_context_tests;
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
 pub struct Author(pub usize);
-#[derive(
-    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize, Default,
-)]
+
+#[derive(Eq, PartialEq, Copy, Clone, Hash, Debug, Serialize, Deserialize, Default)]
 pub struct Signature(pub usize, pub u64);
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+
+#[derive(Eq, PartialEq, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
 pub struct HashValue(pub u64);
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Serialize, Deserialize)]
 pub struct State(pub u64);
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Debug, Serialize, Deserialize)]
+
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Serialize, Deserialize)]
 pub struct Command {
     pub proposer: Author,
     pub index: usize,
@@ -69,7 +70,7 @@ impl SimulatedLedgerState {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SimulatedContext<Config> {
     author: Author,
     config: Config,
@@ -79,25 +80,6 @@ pub struct SimulatedContext<Config> {
     last_committed_ledger_state: SimulatedLedgerState,
     pending_ledger_states: HashMap<State, SimulatedLedgerState>,
 }
-
-// TODO: remove (see comment in SmrContext)
-impl<Config> std::cmp::PartialOrd for SimulatedContext<Config> {
-    fn partial_cmp(&self, _other: &Self) -> Option<std::cmp::Ordering> {
-        panic!("not implemented");
-    }
-}
-impl<Config> std::cmp::Ord for SimulatedContext<Config> {
-    fn cmp(&self, _other: &Self) -> std::cmp::Ordering {
-        panic!("not implemented");
-    }
-}
-impl<Config> std::cmp::PartialEq for SimulatedContext<Config> {
-    fn eq(&self, _other: &Self) -> bool {
-        panic!("not implemented");
-    }
-}
-
-impl<Config> std::cmp::Eq for SimulatedContext<Config> {}
 
 impl<Config> SimulatedContext<Config> {
     pub fn new(
@@ -295,4 +277,4 @@ impl<Config> Storage<State> for SimulatedContext<Config> {
     }
 }
 
-impl<Config> SmrContext for SimulatedContext<Config> where Config: Clone + Debug + 'static {}
+impl<Config> SmrContext for SimulatedContext<Config> where Config: Eq + Clone + Debug + 'static {}

--- a/bft-lib/src/simulated_context.rs
+++ b/bft-lib/src/simulated_context.rs
@@ -295,7 +295,4 @@ impl<Config> Storage<State> for SimulatedContext<Config> {
     }
 }
 
-impl<Config> SmrContext for SimulatedContext<Config> where
-    Config: Serialize + serde::de::DeserializeOwned + Clone + Debug + 'static
-{
-}
+impl<Config> SmrContext for SimulatedContext<Config> where Config: Clone + Debug + 'static {}

--- a/bft-lib/src/smr_context.rs
+++ b/bft-lib/src/smr_context.rs
@@ -60,7 +60,7 @@ pub trait StateFinalizer<State> {
 }
 
 /// How to read epoch ids and configuration from a state.
-pub trait EpochReader<Author, State> {
+pub trait EpochReader<Author: Hash, State> {
     /// Read the id of the epoch in a state.
     fn read_epoch_id(&self, state: &State) -> EpochId;
 
@@ -97,7 +97,7 @@ pub trait CryptographicModule {
     type Hasher: std::io::Write;
 
     /// The identity (ie. public key) of a node.
-    type Author: Serialize + DeserializeOwned + Debug + Copy + Eq + Ord + Hash + 'static;
+    type Author: Serialize + DeserializeOwned + Debug + Copy + Eq + Hash + 'static;
 
     /// The type of signature values.
     type Signature: Serialize + DeserializeOwned + Debug + Copy + Eq + Hash + 'static;

--- a/bft-lib/src/unit_tests/configuration_tests.rs
+++ b/bft-lib/src/unit_tests/configuration_tests.rs
@@ -5,10 +5,7 @@ use super::*;
 
 #[test]
 fn test_count() {
-    let mut rights = BTreeMap::new();
-    rights.insert("0", 1);
-    rights.insert("1", 2);
-    rights.insert("2", 3);
+    let rights = vec![("0", 1), ("1", 2), ("2", 3)];
     let config = EpochConfiguration::new(rights);
     assert_eq!(config.total_votes, 6);
 
@@ -18,14 +15,11 @@ fn test_count() {
 
 #[test]
 fn test_pick_author() {
-    let mut rights = BTreeMap::new();
-    rights.insert("0", 1);
-    rights.insert("1", 2);
-    rights.insert("2", 5);
+    let rights = vec![("0", 1), ("1", 2), ("2", 5)];
     let config = EpochConfiguration::new(rights);
 
-    let mut hits = BTreeMap::new();
-    for seed in 10..(10 + config.total_votes) {
+    let mut hits = HashMap::new();
+    for seed in 20..(20 + config.total_votes) {
         let author = config.pick_author(seed as u64);
         *hits.entry(author).or_insert(0) += 1;
     }
@@ -35,9 +29,9 @@ fn test_pick_author() {
 }
 
 fn equal_configuration(num_nodes: usize) -> EpochConfiguration<usize> {
-    let mut voting_rights = BTreeMap::new();
+    let mut voting_rights = Vec::new();
     for index in 0..num_nodes {
-        voting_rights.insert(index, 1);
+        voting_rights.push((index, 1));
     }
     EpochConfiguration::new(voting_rights)
 }

--- a/librabft-v2/Cargo.toml
+++ b/librabft-v2/Cargo.toml
@@ -15,8 +15,8 @@ simulator = ["bft-lib/simulator"]
 env_logger = "0.8.1"
 anyhow = "1.0"
 log = "0.4.6"
-rand = "0.7.3"
-clap = "2.33"
+rand = "0.8.3"
+clap = "2.33.3"
 csv = "1.1"
 futures = "0.3.14"
 serde = { version = "1.0", features = ["derive"] }

--- a/librabft-v2/src/data_sync.rs
+++ b/librabft-v2/src/data_sync.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeSet;
 mod data_sync_tests;
 
 // -- BEGIN FILE data_sync --
-#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct DataSyncNotification<Context: SmrContext> {
     /// Current epoch identifier.
     current_epoch: EpochId,
@@ -38,7 +38,7 @@ pub struct DataSyncNotification<Context: SmrContext> {
     proposed_block: Option<Block<Context>>,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct DataSyncRequest {
     /// Current epoch identifier.
     current_epoch: EpochId,
@@ -46,7 +46,7 @@ pub struct DataSyncRequest {
     known_quorum_certificates: BTreeSet<Round>,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct DataSyncResponse<Context: SmrContext> {
     /// Current epoch identifier.
     current_epoch: EpochId,

--- a/librabft-v2/src/main.rs
+++ b/librabft-v2/src/main.rs
@@ -16,20 +16,20 @@ type Context = SimulatedContext<NodeConfig>;
 
 fn main() {
     let args = get_arguments();
-
     env_logger::init();
+    let seed = args.seed.unwrap_or_else(|| rand::thread_rng().gen());
+    warn!("seed: {}", seed);
     let context_factory = |author, num_nodes| {
         let config = NodeConfig {
             target_commit_interval: args.target_commit_interval,
             delta: args.delta,
-            gamma: args.gamma,
-            lambda: args.lambda,
+            gamma_times_100: (args.gamma * 100.) as u32,
+            lambda_times_100: (args.lambda * 100.) as u32,
         };
+        warn!("config for {:?}: {:?}", author, config);
         SimulatedContext::new(author, config, num_nodes, args.commands_per_epoch)
     };
     let delay_distribution = simulator::RandomDelay::new(args.mean, args.variance);
-    let seed = args.seed.unwrap_or_else(|| rand::thread_rng().gen());
-    warn!("seed: {}", seed);
     let mut sim = simulator::Simulator::<
         NodeState<Context>,
         Context,

--- a/librabft-v2/src/record.rs
+++ b/librabft-v2/src/record.rs
@@ -13,7 +13,7 @@ mod record_tests;
 
 // -- BEGIN FILE records --
 /// A record read from the network.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub(crate) enum Record<Context: SmrContext> {
     /// Proposed block, containing a command, e.g. a set of Libra transactions.
     #[serde(bound(serialize = "Context: SmrContext"))]
@@ -42,13 +42,13 @@ pub(crate) type QuorumCertificate<C> =
 
 pub(crate) type Timeout<C> = SignedValue<Timeout_<C>, <C as CryptographicModule>::Signature>;
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct BlockHash<V>(pub V);
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct QuorumCertificateHash<V>(pub V);
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Block_<Context: SmrContext> {
     /// User-defined command to execute in the state machine.
     pub(crate) command: Context::Command,
@@ -62,7 +62,7 @@ pub(crate) struct Block_<Context: SmrContext> {
     pub(crate) author: Context::Author,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Vote_<Context: SmrContext> {
     /// The current epoch.
     pub(crate) epoch_id: EpochId,
@@ -79,7 +79,7 @@ pub(crate) struct Vote_<Context: SmrContext> {
     pub(crate) author: Context::Author,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct QuorumCertificate_<Context: SmrContext> {
     /// The current epoch.
     pub(crate) epoch_id: EpochId,
@@ -98,7 +98,7 @@ pub struct QuorumCertificate_<Context: SmrContext> {
     pub(crate) author: Context::Author,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Timeout_<Context: SmrContext> {
     /// The current epoch.
     pub(crate) epoch_id: EpochId,

--- a/librabft-v2/src/unit_tests/data_sync_tests.rs
+++ b/librabft-v2/src/unit_tests/data_sync_tests.rs
@@ -4,7 +4,6 @@
 use super::*;
 use crate::node::NodeConfig;
 use bft_lib::simulated_context::SimulatedContext;
-use serde_json;
 use std::collections::BTreeSet;
 
 #[test]

--- a/librabft-v2/tests/simulated_run.rs
+++ b/librabft-v2/tests/simulated_run.rs
@@ -40,7 +40,7 @@ fn make_simulator(
 
 #[test]
 fn test_simulated_run_3_nodes() {
-    let mut sim = make_simulator(/* seed */ 37, /* nodes */ 3);
+    let mut sim = make_simulator(/* seed */ 52, /* nodes */ 3);
     let contexts = sim.loop_until(simulator::GlobalTime(1000), None);
     let num_commits = contexts
         .iter()
@@ -54,22 +54,22 @@ fn test_simulated_run_3_nodes() {
     assert_eq!(
         last_committed_states,
         [
-            State(7335051808155289996),
-            State(7335051808155289996),
-            State(7335051808155289996)
-        ]
+            State(11134312813757838303),
+            State(11134312813757838303),
+            State(11134312813757838303)
+        ],
     );
 }
 
 #[test]
 fn test_simulated_run_8_nodes() {
-    let mut sim = make_simulator(/* seed */ 37, /* nodes */ 8);
+    let mut sim = make_simulator(/* seed */ 48, /* nodes */ 8);
     let contexts = sim.loop_until(simulator::GlobalTime(1000), None);
     let num_commits = contexts
         .iter()
         .map(|context| context.committed_history().len())
         .collect::<Vec<_>>();
-    assert_eq!(num_commits, [31, 31, 31, 31, 31, 32, 31, 31]);
+    assert_eq!(num_commits, [28, 28, 28, 28, 28, 28, 28, 30]);
     let last_committed_states = contexts
         .iter()
         .map(|context| context.last_committed_state())
@@ -77,14 +77,14 @@ fn test_simulated_run_8_nodes() {
     assert_eq!(
         last_committed_states,
         [
-            State(15928410698780818363),
-            State(15928410698780818363),
-            State(15928410698780818363),
-            State(15928410698780818363),
-            State(15928410698780818363),
-            State(4966200521533607485),
-            State(15928410698780818363),
-            State(15928410698780818363)
+            State(12785928431398617538),
+            State(12785928431398617538),
+            State(12785928431398617538),
+            State(12785928431398617538),
+            State(12785928431398617538),
+            State(12785928431398617538),
+            State(12785928431398617538),
+            State(4890275890002623733)
         ]
     );
 }

--- a/librabft-v2/tests/simulated_run.rs
+++ b/librabft-v2/tests/simulated_run.rs
@@ -29,8 +29,8 @@ fn make_simulator(
         let config = NodeConfig {
             target_commit_interval: Duration(100000),
             delta: Duration(20),
-            gamma: 2.0,
-            lambda: 0.5,
+            gamma_times_100: 200,
+            lambda_times_100: 50,
         };
         SimulatedContext::new(author, config, num_nodes, 30000)
     };

--- a/librabft-v2/tests/simulated_run.rs
+++ b/librabft-v2/tests/simulated_run.rs
@@ -1,0 +1,90 @@
+// Copyright (c) Calibra Research
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "simulator")]
+
+use bft_lib::{
+    base_types::*,
+    simulated_context::{SimulatedContext, State},
+    simulator,
+};
+use librabft_v2::{
+    data_sync::*,
+    node::{NodeConfig, NodeState},
+};
+
+type Context = SimulatedContext<NodeConfig>;
+
+fn make_simulator(
+    seed: u64,
+    nodes: usize,
+) -> simulator::Simulator<
+    NodeState<Context>,
+    Context,
+    DataSyncNotification<Context>,
+    DataSyncRequest,
+    DataSyncResponse<Context>,
+> {
+    let context_factory = |author, num_nodes| {
+        let config = NodeConfig {
+            target_commit_interval: Duration(100000),
+            delta: Duration(20),
+            gamma: 2.0,
+            lambda: 0.5,
+        };
+        SimulatedContext::new(author, config, num_nodes, 30000)
+    };
+    let delay_distribution = simulator::RandomDelay::new(10.0, 4.0);
+    simulator::Simulator::new(seed, nodes, delay_distribution, context_factory)
+}
+
+#[test]
+fn test_simulated_run_3_nodes() {
+    let mut sim = make_simulator(/* seed */ 37, /* nodes */ 3);
+    let contexts = sim.loop_until(simulator::GlobalTime(1000), None);
+    let num_commits = contexts
+        .iter()
+        .map(|context| context.committed_history().len())
+        .collect::<Vec<_>>();
+    assert_eq!(num_commits, [27, 27, 27]);
+    let last_committed_states = contexts
+        .iter()
+        .map(|context| context.last_committed_state())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        last_committed_states,
+        [
+            State(7335051808155289996),
+            State(7335051808155289996),
+            State(7335051808155289996)
+        ]
+    );
+}
+
+#[test]
+fn test_simulated_run_8_nodes() {
+    let mut sim = make_simulator(/* seed */ 37, /* nodes */ 8);
+    let contexts = sim.loop_until(simulator::GlobalTime(1000), None);
+    let num_commits = contexts
+        .iter()
+        .map(|context| context.committed_history().len())
+        .collect::<Vec<_>>();
+    assert_eq!(num_commits, [31, 31, 31, 31, 31, 32, 31, 31]);
+    let last_committed_states = contexts
+        .iter()
+        .map(|context| context.last_committed_state())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        last_committed_states,
+        [
+            State(15928410698780818363),
+            State(15928410698780818363),
+            State(15928410698780818363),
+            State(15928410698780818363),
+            State(15928410698780818363),
+            State(4966200521533607485),
+            State(15928410698780818363),
+            State(15928410698780818363)
+        ]
+    );
+}


### PR DESCRIPTION
Remove the trait constraint `PartialOrd + Ord` almost everywhere.

In practice, this solves the complications with applying `#[derive(..)]` macros on types parameterized over `Context` in the sense that the trait constraints that remain in `SmrContext` (that is: `Eq + Clone + Debug + 'static`) are easy to fulfill anyway for any future implementation of `Context`.

While debugging, I decided it was time to add a proper end-to-end test and had to fix a few things to make it 100% deterministic.

Remaining caveats:
* `Context: 'static` is a bit unfortunate. I think this is a limitation of the Rust compiler (which fails to prove 'static on a result type, see error message).
* `Eq` is not derivable for floats.