### PR TITLE
Storage APIs

### DIFF
--- a/bft-lib/Cargo.toml
+++ b/bft-lib/Cargo.toml
@@ -24,4 +24,4 @@ csv = "1.1"
 bcs = "0.1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-name = "0.1.1"
-futures = { version = "0.3.14", features = ["executor"] }
+futures = { version = "0.3.15", features = ["executor"] }

--- a/bft-lib/src/base_types.rs
+++ b/bft-lib/src/base_types.rs
@@ -12,7 +12,7 @@ mod base_type_tests;
 // TODO: add error handling (using thiserror to define an error type?) + remove Unpin
 // Alternatively, we may want to use a generic associated type when there are available on
 // rust-stable:   https://github.com/rust-lang/rust/issues/44265
-pub type AsyncResult<T> = Box<dyn std::future::Future<Output = T> + Unpin + 'static>;
+pub type AsyncResult<'a, T> = futures::future::BoxFuture<'a, T>;
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/bft-lib/src/base_types.rs
+++ b/bft-lib/src/base_types.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Calibra Research
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Error;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -9,12 +8,12 @@ use std::fmt;
 #[path = "unit_tests/base_type_tests.rs"]
 mod base_type_tests;
 
-// TODO: add error handling (using thiserror to define an error type?) + remove Unpin
-// Alternatively, we may want to use a generic associated type when there are available on
-// rust-stable:   https://github.com/rust-lang/rust/issues/44265
-pub type AsyncResult<'a, T> = futures::future::BoxFuture<'a, T>;
+// TODO: better error type
+pub type Result<T> = std::result::Result<T, anyhow::Error>;
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Async<'a, T> = futures::future::BoxFuture<'a, T>;
+
+pub type AsyncResult<'a, T> = futures::future::BoxFuture<'a, Result<T>>;
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, Debug)]
 pub struct Round(pub usize);

--- a/bft-lib/src/interfaces.rs
+++ b/bft-lib/src/interfaces.rs
@@ -45,7 +45,7 @@ pub trait ConsensusNode<Context: SmrContext>: Sized {
 
     /// Save the "staged" node state into storage, possibly after applying additional async
     /// operations.
-    fn save_node(&mut self, context: &mut Context) -> AsyncResult<()>;
+    fn save_node<'a>(&'a mut self, context: &'a mut Context) -> AsyncResult<'a, ()>;
 }
 // -- END FILE --
 
@@ -63,25 +63,25 @@ pub trait DataSyncNode<Context> {
     fn create_request(&self) -> Self::Request;
 
     /// Sender role: handle a request from a receiver.
-    fn handle_request(
-        &self,
-        context: &mut Context,
+    fn handle_request<'a>(
+        &'a self,
+        context: &'a mut Context,
         request: Self::Request,
-    ) -> Async<Self::Response>;
+    ) -> Async<'a, Self::Response>;
 
     /// Receiver role: accept or refuse a notification.
-    fn handle_notification(
-        &mut self,
-        context: &mut Context,
+    fn handle_notification<'a>(
+        &'a mut self,
+        context: &'a mut Context,
         notification: Self::Notification,
-    ) -> Async<Option<Self::Request>>;
+    ) -> Async<'a, Option<Self::Request>>;
 
     /// Receiver role: receive data.
-    fn handle_response(
-        &mut self,
-        context: &mut Context,
+    fn handle_response<'a>(
+        &'a mut self,
+        context: &'a mut Context,
         response: Self::Response,
         clock: NodeTime,
-    ) -> Async<()>;
+    ) -> Async<'a, ()>;
 }
 // -- END FILE --

--- a/bft-lib/src/interfaces.rs
+++ b/bft-lib/src/interfaces.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    base_types::{AsyncResult, NodeTime},
+    base_types::{Async, AsyncResult, NodeTime},
     smr_context::SmrContext,
 };
 
@@ -67,14 +67,14 @@ pub trait DataSyncNode<Context> {
         &self,
         context: &mut Context,
         request: Self::Request,
-    ) -> AsyncResult<Self::Response>;
+    ) -> Async<Self::Response>;
 
     /// Receiver role: accept or refuse a notification.
     fn handle_notification(
         &mut self,
         context: &mut Context,
         notification: Self::Notification,
-    ) -> AsyncResult<Option<Self::Request>>;
+    ) -> Async<Option<Self::Request>>;
 
     /// Receiver role: receive data.
     fn handle_response(
@@ -82,6 +82,6 @@ pub trait DataSyncNode<Context> {
         context: &mut Context,
         response: Self::Response,
         clock: NodeTime,
-    ) -> AsyncResult<()>;
+    ) -> Async<()>;
 }
 // -- END FILE --

--- a/bft-lib/src/interfaces.rs
+++ b/bft-lib/src/interfaces.rs
@@ -57,10 +57,10 @@ pub trait DataSyncNode<Context> {
     type Response;
 
     /// Sender role: what to send to initiate a data-synchronization exchange with a receiver.
-    fn create_notification(&self) -> Self::Notification;
+    fn create_notification(&self, context: &Context) -> Self::Notification;
 
     /// Query role: what to send to initiate a query exchange and obtain data from a sender.
-    fn create_request(&self) -> Self::Request;
+    fn create_request(&self, context: &Context) -> Self::Request;
 
     /// Sender role: handle a request from a receiver.
     fn handle_request<'a>(

--- a/bft-lib/src/simulated_context.rs
+++ b/bft-lib/src/simulated_context.rs
@@ -265,20 +265,20 @@ impl CryptographicModule for SimulatedContext {
         self.author
     }
 
-    fn sign(&mut self, hash: Self::HashValue) -> Result<Self::Signature> {
-        Ok(Signature(self.author.0, hash))
+    fn sign(&mut self, hash: Self::HashValue) -> Self::Signature {
+        Signature(self.author.0, hash)
     }
 }
 
 impl Storage for SimulatedContext {
     fn read_value(&mut self, key: String) -> AsyncResult<Option<Vec<u8>>> {
         let value = self.database.get(&key).cloned();
-        Box::pin(future::ready(value))
+        Box::pin(future::ready(Ok(value)))
     }
 
     fn store_value(&mut self, key: String, value: Vec<u8>) -> AsyncResult<()> {
         self.database.insert(key, value);
-        Box::pin(future::ready(()))
+        Box::pin(future::ready(Ok(())))
     }
 }
 

--- a/bft-lib/src/simulated_context.rs
+++ b/bft-lib/src/simulated_context.rs
@@ -83,25 +83,16 @@ pub struct SimulatedContext {
 }
 
 impl SimulatedContext {
-    pub fn new(
-        author: Author,
-        database: HashMap<String, Vec<u8>>,
-        num_nodes: usize,
-        max_command_per_epoch: usize,
-    ) -> Self {
+    pub fn new(author: Author, num_nodes: usize, max_command_per_epoch: usize) -> Self {
         SimulatedContext {
             author,
-            database,
+            database: HashMap::new(),
             num_nodes,
             max_command_per_epoch,
             next_fetched_command_index: 0,
             last_committed_ledger_state: SimulatedLedgerState::new(),
             pending_ledger_states: HashMap::new(),
         }
-    }
-
-    pub fn last_committed_state(&self) -> State {
-        self.last_committed_ledger_state.key()
     }
 
     pub fn committed_history(&self) -> &Vec<(Command, NodeTime)> {
@@ -164,10 +155,6 @@ impl CommandExecutor<Author, State, Command> for SimulatedContext {
             }
         }
     }
-
-    fn initial_state(&self) -> State {
-        SimulatedLedgerState::new().key()
-    }
 }
 
 impl StateFinalizer<State> for SimulatedContext {
@@ -202,6 +189,10 @@ impl StateFinalizer<State> for SimulatedContext {
         self.pending_ledger_states
             .remove(state)
             .expect("Discarded states should be known");
+    }
+
+    fn last_committed_state(&self) -> State {
+        self.last_committed_ledger_state.key()
     }
 }
 

--- a/bft-lib/src/simulator.rs
+++ b/bft-lib/src/simulator.rs
@@ -218,7 +218,8 @@ where
                 let node_time = NodeTime(0);
                 let scheduled_time = GlobalTime::from_node_time(node_time, startup_time);
                 let event = Event::UpdateTimerEvent { author };
-                let node = block_on(Node::load_node(&mut context, node_time));
+                let node = block_on(Node::load_node(&mut context, node_time))
+                    .expect("loading nodes in simulator should not fail");
                 trace!(
                     "Scheduling initial event {:?} for time {:?}",
                     event,
@@ -304,7 +305,8 @@ where
         );
         let mut node = self.nodes.get_mut(author.0).unwrap();
         // First, we must save the state of the node.
-        block_on(node.node.save_node(&mut node.context));
+        block_on(node.node.save_node(&mut node.context))
+            .expect("saving nodes should not fail in simulator");
         // Then, schedule the next call to `update_node`.
         let new_scheduled_time = {
             let new_scheduled_time = std::cmp::max(

--- a/bft-lib/src/simulator.rs
+++ b/bft-lib/src/simulator.rs
@@ -303,8 +303,8 @@ where
             "@{:?} Processing node actions for {:?}: {:?}",
             clock, author, actions
         );
-        let mut node = self.nodes.get_mut(author.0).unwrap();
         // First, we must save the state of the node.
+        let mut node = self.simulated_node_mut(author);
         block_on(node.node.save_node(&mut node.context))
             .expect("saving nodes should not fail in simulator");
         // Then, schedule the next call to `update_node`.
@@ -341,7 +341,10 @@ where
             }
         }
         receivers.shuffle(&mut self.rng);
-        let notification = self.simulated_node(author).node.create_notification();
+        let notification = {
+            let node = self.simulated_node(author);
+            node.node.create_notification(&node.context)
+        };
         for receiver in receivers {
             self.schedule_network_event(Event::DataSyncNotifyEvent {
                 sender: author,
@@ -359,7 +362,10 @@ where
                 }
             }
         }
-        let request = self.simulated_node(author).node.create_request();
+        let request = {
+            let node = self.simulated_node(author);
+            node.node.create_request(&node.context)
+        };
         let mut senders = senders.into_iter().collect::<Vec<_>>();
         senders.shuffle(&mut self.rng);
         for sender in senders {

--- a/bft-lib/src/smr_context.rs
+++ b/bft-lib/src/smr_context.rs
@@ -123,7 +123,7 @@ pub trait CryptographicModule {
 
     /// Sign a message using the private key of this node.
     // TODO: make async to enable HSM implementations.
-    fn sign(&mut self, hash: Self::HashValue) -> Result<Self::Signature>;
+    fn sign(&mut self, hash: Self::HashValue) -> Self::Signature;
 }
 
 pub trait Storage {
@@ -178,7 +178,7 @@ impl<T, S> SignedValue<T, S> {
     {
         assert_eq!(value.author(), context.author());
         let h = context.hash(&value);
-        let signature = context.sign(h).expect("Signing should not fail");
+        let signature = context.sign(h);
         SignedValue { value, signature }
     }
 

--- a/bft-lib/src/smr_context.rs
+++ b/bft-lib/src/smr_context.rs
@@ -37,9 +37,6 @@ pub trait CommandExecutor<Author, State, Command> {
         // Suggest to reward the voters of the previous block, if any.
         previous_voters: Vec<Author>,
     ) -> Option<State>;
-
-    /// The initial state (aka "genesis") before any command is executed.
-    fn initial_state(&self) -> State;
 }
 
 /// A commit certificate.
@@ -60,6 +57,9 @@ pub trait StateFinalizer<State> {
 
     /// Report that a state was discarded.
     fn discard(&mut self, state: &State);
+
+    /// Obtain the last committed state, if any, and otherwise the genesis state.
+    fn last_committed_state(&self) -> State;
 }
 
 /// How to read epoch ids and configuration from a state.

--- a/bft-lib/src/unit_tests/simulated_context_tests.rs
+++ b/bft-lib/src/unit_tests/simulated_context_tests.rs
@@ -17,7 +17,6 @@ impl BcsSignable for Bar {}
 fn test_hashing_and_signing() {
     let mut context = SimulatedContext::new(
         Author(0),
-        HashMap::new(),
         /* num_nodes */ 2,
         /* max commands per epoch */ 2,
     );
@@ -81,7 +80,6 @@ impl CommitCertificate<State> for DummyCertificate {
 fn test_simulated_context() {
     let mut context = SimulatedContext::new(
         Author(0),
-        HashMap::new(),
         /* num_nodes */ 2,
         /* max commands per epoch */ 2,
     );

--- a/bft-lib/src/unit_tests/simulated_context_tests.rs
+++ b/bft-lib/src/unit_tests/simulated_context_tests.rs
@@ -17,7 +17,7 @@ impl BcsSignable for Bar {}
 fn test_hashing_and_signing() {
     let mut context = SimulatedContext::new(
         Author(0),
-        (),
+        HashMap::new(),
         /* num_nodes */ 2,
         /* max commands per epoch */ 2,
     );
@@ -81,7 +81,7 @@ impl CommitCertificate<State> for DummyCertificate {
 fn test_simulated_context() {
     let mut context = SimulatedContext::new(
         Author(0),
-        (),
+        HashMap::new(),
         /* num_nodes */ 2,
         /* max commands per epoch */ 2,
     );

--- a/bft-lib/src/unit_tests/simulated_context_tests.rs
+++ b/bft-lib/src/unit_tests/simulated_context_tests.rs
@@ -24,7 +24,7 @@ fn test_hashing_and_signing() {
     let h1 = context.hash(&Foo(35));
     let h2 = context.hash(&Bar(35));
 
-    let sig1 = context.sign(h1).unwrap();
+    let sig1 = context.sign(h1);
     assert!(context.verify(Author(0), h1, sig1).is_ok());
     assert!(context.verify(Author(1), h1, sig1).is_err());
     assert!(context.verify(Author(0), h2, sig1).is_err());

--- a/librabft-v2/Cargo.toml
+++ b/librabft-v2/Cargo.toml
@@ -18,13 +18,11 @@ log = "0.4.6"
 rand = "0.8.3"
 clap = "2.33.3"
 csv = "1.1"
-futures = "0.3.14"
+futures = "0.3.15"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 bft-lib = { path = "../bft-lib" }
-
-[dev-dependencies]
-serde_json = "1.0"
 
 [[bin]]
 name = "librabft_simulator"

--- a/librabft-v2/Cargo.toml
+++ b/librabft-v2/Cargo.toml
@@ -20,9 +20,12 @@ clap = "2.33.3"
 csv = "1.1"
 futures = "0.3.15"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+bincode = "1.3.3"
 
 bft-lib = { path = "../bft-lib" }
+
+[dev-dependencies]
+serde_json = "1.0"
 
 [[bin]]
 name = "librabft_simulator"

--- a/librabft-v2/src/data_sync.rs
+++ b/librabft-v2/src/data_sync.rs
@@ -117,7 +117,7 @@ where
         &mut self,
         smr_context: &mut Context,
         notification: Self::Notification,
-    ) -> AsyncResult<Option<Self::Request>> {
+    ) -> Async<Option<Self::Request>> {
         // Whether we should request more data because of a new epoch or missings records.
         let mut should_sync = false;
         // Note that malicious nodes can always lie to make us send a request, but they may as
@@ -187,7 +187,7 @@ where
         &self,
         _smr_context: &mut Context,
         request: Self::Request,
-    ) -> AsyncResult<Self::Response> {
+    ) -> Async<Self::Response> {
         let mut records = Vec::new();
         if let Some(store) = self.record_store_at(request.current_epoch) {
             records.push((
@@ -214,7 +214,7 @@ where
         smr_context: &mut Context,
         response: Self::Response,
         clock: NodeTime,
-    ) -> AsyncResult<()> {
+    ) -> Async<()> {
         let num_records = response.records.len();
         // Insert all the records in order.
         // Process the commits so that new epochs are created along the way.

--- a/librabft-v2/src/data_sync.rs
+++ b/librabft-v2/src/data_sync.rs
@@ -61,7 +61,7 @@ pub struct DataSyncResponse<Context: SmrContext> {
 
 impl<Context> NodeState<Context>
 where
-    Context: SmrContext<Config = NodeConfig>,
+    Context: SmrContext,
 {
     fn create_request_internal(&self) -> DataSyncRequest {
         DataSyncRequest {
@@ -73,7 +73,7 @@ where
 
 impl<Context> DataSyncNode<Context> for NodeState<Context>
 where
-    Context: SmrContext<Config = NodeConfig>,
+    Context: SmrContext,
 {
     type Notification = DataSyncNotification<Context>;
     type Request = DataSyncRequest;
@@ -176,7 +176,7 @@ where
         } else {
             None
         };
-        Box::new(future::ready(value))
+        Box::pin(future::ready(value))
     }
 
     fn create_request(&self) -> Self::Request {
@@ -206,7 +206,7 @@ where
             current_epoch: self.epoch_id(),
             records,
         };
-        Box::new(future::ready(value))
+        Box::pin(future::ready(value))
     }
 
     fn handle_response(
@@ -239,6 +239,6 @@ where
             self.process_commits(smr_context);
             self.update_tracker(clock);
         }
-        Box::new(future::ready(()))
+        Box::pin(future::ready(()))
     }
 }

--- a/librabft-v2/src/main.rs
+++ b/librabft-v2/src/main.rs
@@ -21,20 +21,14 @@ fn main() {
     let seed = args.seed.unwrap_or_else(|| rand::thread_rng().gen());
     warn!("seed: {}", seed);
     let context_factory = |author, num_nodes| {
-        let mut context = SimulatedContext::new(
-            author,
-            std::collections::HashMap::new(),
-            num_nodes,
-            args.commands_per_epoch,
-        );
+        let mut context = SimulatedContext::new(author, num_nodes, args.commands_per_epoch);
         let config = NodeConfig {
             target_commit_interval: args.target_commit_interval,
             delta: args.delta,
-            gamma_times_100: (args.gamma * 100.) as u32,
-            lambda_times_100: (args.lambda * 100.) as u32,
+            gamma: args.gamma,
+            lambda: args.lambda,
         };
-        let initial_state = context.last_committed_state();
-        let mut node = NodeState::new(author, config, initial_state, NodeTime(0), &context);
+        let mut node = NodeState::make_initial_state(&context, config, NodeTime(0));
         block_on(node.save_node(&mut context)).unwrap();
         context
     };

--- a/librabft-v2/src/node.rs
+++ b/librabft-v2/src/node.rs
@@ -78,22 +78,18 @@ impl CommitTracker {
 pub struct NodeConfig {
     pub target_commit_interval: Duration,
     pub delta: Duration,
-    pub gamma_times_100: u32,
-    pub lambda_times_100: u32,
+    pub gamma: f64,
+    pub lambda: f64,
 }
 
 impl<Context> NodeState<Context>
 where
     Context: SmrContext,
 {
-    pub fn new(
-        author: Context::Author,
-        config: NodeConfig,
-        initial_state: Context::State,
-        node_time: NodeTime,
-        context: &Context,
-    ) -> Self {
+    pub fn make_initial_state(context: &Context, config: NodeConfig, node_time: NodeTime) -> Self {
+        let initial_state = context.last_committed_state();
         let epoch_id = context.read_epoch_id(&initial_state);
+        let author = context.author();
         let tracker = CommitTracker::new(epoch_id, node_time, config.target_commit_interval);
         let record_store = RecordStoreState::new(
             Self::initial_hash(context, epoch_id),
@@ -105,8 +101,8 @@ where
             epoch_id,
             node_time,
             config.delta,
-            config.gamma_times_100 as f64 / 100.,
-            config.lambda_times_100 as f64 / 100.,
+            config.gamma,
+            config.lambda,
         );
         NodeState {
             record_store,

--- a/librabft-v2/src/node.rs
+++ b/librabft-v2/src/node.rs
@@ -225,17 +225,18 @@ where
                 &context
                     .read_value("config".to_string())
                     .await
+                    .expect("failed to load node config")
                     .expect("missing config value"),
             )
-            .expect("failed to load node config");
+            .expect("failed to deserialize node config");
             let state = context.initial_state();
-            NodeState::new(author, config, state, node_time, &*context)
+            Ok(NodeState::new(author, config, state, node_time, &*context))
         })
     }
 
     fn save_node(&mut self, _context: &mut Context) -> AsyncResult<()> {
         // TODO
-        Box::pin(future::ready(()))
+        Box::pin(future::ready(Ok(())))
     }
 
     fn update_node(

--- a/librabft-v2/src/pacemaker.rs
+++ b/librabft-v2/src/pacemaker.rs
@@ -6,6 +6,7 @@ use bft_lib::{
     base_types::{Duration, EpochId, NodeTime, Round},
     smr_context::SmrContext,
 };
+use serde::{Deserialize, Serialize};
 use std::cmp::{max, min};
 
 #[cfg(test)]
@@ -55,7 +56,7 @@ pub(crate) trait Pacemaker<Context: SmrContext> {
 // -- END FILE --
 
 // -- BEGIN FILE pacemaker_state --
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub(crate) struct PacemakerState<Context: SmrContext> {
     /// Active epoch.
     active_epoch: EpochId,
@@ -64,7 +65,7 @@ pub(crate) struct PacemakerState<Context: SmrContext> {
     /// Leader of the active round.
     active_leader: Option<Context::Author>,
     /// Time at which we entered the round.
-    active_round_start_time: NodeTime,
+    pub(crate) active_round_start_time: NodeTime,
     /// Maximal duration of the current round.
     active_round_duration: Duration,
     /// Maximal duration of the first round after a commit rule.

--- a/librabft-v2/src/record_store.rs
+++ b/librabft-v2/src/record_store.rs
@@ -12,6 +12,7 @@ use bft_lib::{
     smr_context::{SignedValue, SmrContext},
 };
 use log::{debug, info, warn};
+use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeSet, HashMap},
     fmt::Debug,
@@ -86,7 +87,9 @@ pub(crate) trait RecordStore<Context: SmrContext> {
 // -- END FILE --
 
 // -- BEGIN FILE record_store_state --
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(bound(serialize = "Context: SmrContext"))]
+#[serde(bound(deserialize = "Context: SmrContext"))]
 pub struct RecordStoreState<Context: SmrContext> {
     /// Epoch initialization.
     epoch_id: EpochId,
@@ -116,7 +119,9 @@ pub struct RecordStoreState<Context: SmrContext> {
 }
 
 /// Counting votes for a proposed block and its execution state.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(bound(serialize = "Context: SmrContext"))]
+#[serde(bound(deserialize = "Context: SmrContext"))]
 enum ElectionState<Context: SmrContext> {
     Ongoing {
         ballot: HashMap<(BlockHash<Context::HashValue>, Context::State), usize>,

--- a/librabft-v2/src/unit_tests/data_sync_tests.rs
+++ b/librabft-v2/src/unit_tests/data_sync_tests.rs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::node::NodeConfig;
 use bft_lib::simulated_context::SimulatedContext;
 use std::collections::BTreeSet;
 
 #[test]
 fn test_serde_notification() {
-    let data = DataSyncNotification::<SimulatedContext<NodeConfig>> {
+    let data = DataSyncNotification::<SimulatedContext> {
         current_epoch: EpochId(0),
         highest_commit_certificate: None,
         highest_quorum_certificate: None,
@@ -17,8 +16,7 @@ fn test_serde_notification() {
         proposed_block: None,
     };
     let message = serde_json::to_string(&data).unwrap();
-    let data2: DataSyncNotification<SimulatedContext<NodeConfig>> =
-        serde_json::from_str(&message).unwrap();
+    let data2: DataSyncNotification<SimulatedContext> = serde_json::from_str(&message).unwrap();
     assert_eq!(data2, data);
 }
 
@@ -35,12 +33,11 @@ fn test_serde_request() {
 
 #[test]
 fn test_serde_response() {
-    let data = DataSyncResponse::<SimulatedContext<NodeConfig>> {
+    let data = DataSyncResponse::<SimulatedContext> {
         current_epoch: EpochId(0),
         records: Vec::new(),
     };
     let message = serde_json::to_string(&data).unwrap();
-    let data2: DataSyncResponse<SimulatedContext<NodeConfig>> =
-        serde_json::from_str(&message).unwrap();
+    let data2: DataSyncResponse<SimulatedContext> = serde_json::from_str(&message).unwrap();
     assert_eq!(data2, data);
 }

--- a/librabft-v2/src/unit_tests/node_tests.rs
+++ b/librabft-v2/src/unit_tests/node_tests.rs
@@ -10,18 +10,10 @@ use futures::executor::block_on;
 fn test_node() {
     let mut context = SimulatedContext::new(
         Author(0),
-        std::collections::HashMap::new(),
         /* num_nodes */ 1,
         /* max commands per epoch */ 2,
     );
-    let initial_state = context.last_committed_state();
-    let mut node0 = NodeState::new(
-        Author(0),
-        NodeConfig::default(),
-        initial_state.clone(),
-        NodeTime(0),
-        &context,
-    );
+    let mut node0 = NodeState::make_initial_state(&context, NodeConfig::default(), NodeTime(0));
     block_on(node0.save_node(&mut context)).unwrap();
 
     let mut node1 = block_on(NodeState::load_node(&mut context, NodeTime(0))).unwrap();
@@ -29,6 +21,7 @@ fn test_node() {
 
     let epoch_id = EpochId(0);
     let initial_hash = QuorumCertificateHash(context.hash(&epoch_id));
+    let initial_state = context.last_committed_state();
 
     // Make a sequence of blocks / QCs
     let cmd = context.fetch().unwrap();

--- a/librabft-v2/src/unit_tests/node_tests.rs
+++ b/librabft-v2/src/unit_tests/node_tests.rs
@@ -5,12 +5,22 @@ use super::*;
 use crate::{node::NodeConfig, record::BlockHash};
 use bft_lib::{simulated_context::*, smr_context::*};
 use futures::executor::block_on;
+use serde_json;
+
+fn make_database() -> HashMap<String, Vec<u8>> {
+    let mut map = HashMap::new();
+    map.insert(
+        "config".to_string(),
+        serde_json::to_vec(&NodeConfig::default()).unwrap(),
+    );
+    map
+}
 
 #[test]
 fn test_node() {
     let mut context = SimulatedContext::new(
         Author(0),
-        NodeConfig::default(),
+        make_database(),
         /* num_nodes */ 1,
         /* max commands per epoch */ 2,
     );
@@ -40,7 +50,7 @@ fn test_node() {
 
     let v0 = SignedValue::make(
         &mut context,
-        Vote_::<SimulatedContext<NodeConfig>> {
+        Vote_::<SimulatedContext> {
             epoch_id,
             round: Round(1),
             certified_block_hash: block_hash,

--- a/librabft-v2/src/unit_tests/node_tests.rs
+++ b/librabft-v2/src/unit_tests/node_tests.rs
@@ -27,7 +27,7 @@ fn test_node() {
     let epoch_id = EpochId(0);
     let initial_hash = QuorumCertificateHash(context.hash(&epoch_id));
     let initial_state = context.last_committed_state();
-    let mut node1 = block_on(NodeState::load_node(&mut context, NodeTime(0)));
+    let mut node1 = block_on(NodeState::load_node(&mut context, NodeTime(0))).unwrap();
 
     // Make a sequence of blocks / QCs
     let cmd = context.fetch().unwrap();

--- a/librabft-v2/src/unit_tests/record_store_tests.rs
+++ b/librabft-v2/src/unit_tests/record_store_tests.rs
@@ -17,12 +17,7 @@ impl SharedRecordStore {
         for i in 0..num_nodes {
             contexts.insert(
                 Author(i),
-                SimulatedContext::new(
-                    Author(i),
-                    std::collections::HashMap::new(),
-                    num_nodes,
-                    epoch_ttl,
-                ),
+                SimulatedContext::new(Author(i), num_nodes, epoch_ttl),
             );
         }
         let state = contexts.get(&Author(0)).unwrap().last_committed_state();

--- a/librabft-v2/src/unit_tests/record_store_tests.rs
+++ b/librabft-v2/src/unit_tests/record_store_tests.rs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::node::NodeConfig;
 use bft_lib::{simulated_context::*, smr_context::*};
 
 struct SharedRecordStore {
-    store: RecordStoreState<SimulatedContext<NodeConfig>>,
-    contexts: HashMap<Author, SimulatedContext<NodeConfig>>,
+    store: RecordStoreState<SimulatedContext>,
+    contexts: HashMap<Author, SimulatedContext>,
 }
 
 impl SharedRecordStore {
@@ -18,7 +17,12 @@ impl SharedRecordStore {
         for i in 0..num_nodes {
             contexts.insert(
                 Author(i),
-                SimulatedContext::new(Author(i), NodeConfig::default(), num_nodes, epoch_ttl),
+                SimulatedContext::new(
+                    Author(i),
+                    std::collections::HashMap::new(),
+                    num_nodes,
+                    epoch_ttl,
+                ),
             );
         }
         let state = contexts.get(&Author(0)).unwrap().last_committed_state();

--- a/librabft-v2/src/unit_tests/record_tests.rs
+++ b/librabft-v2/src/unit_tests/record_tests.rs
@@ -2,20 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::node::NodeConfig;
 use bft_lib::{simulated_context::*, smr_context::CryptographicModule};
+use std::collections::HashMap;
 
 #[test]
 fn test_block_signing() {
     let mut context = SimulatedContext::new(
         Author(2),
-        NodeConfig::default(),
+        HashMap::new(),
         /* not used */ 0,
         /* not used */ 0,
     );
     let b = SignedValue::make(
         &mut context,
-        Block_::<SimulatedContext<NodeConfig>> {
+        Block_::<SimulatedContext> {
             command: Command {
                 proposer: Author(1),
                 index: 2,
@@ -33,7 +33,7 @@ fn test_block_signing() {
 
     let b2 = SignedValue::make(
         &mut context,
-        Block_::<SimulatedContext<NodeConfig>> {
+        Block_::<SimulatedContext> {
             command: Command {
                 proposer: Author(3),
                 index: 2,

--- a/librabft-v2/src/unit_tests/record_tests.rs
+++ b/librabft-v2/src/unit_tests/record_tests.rs
@@ -3,16 +3,11 @@
 
 use super::*;
 use bft_lib::{simulated_context::*, smr_context::CryptographicModule};
-use std::collections::HashMap;
 
 #[test]
 fn test_block_signing() {
-    let mut context = SimulatedContext::new(
-        Author(2),
-        HashMap::new(),
-        /* not used */ 0,
-        /* not used */ 0,
-    );
+    let mut context =
+        SimulatedContext::new(Author(2), /* not used */ 0, /* not used */ 0);
     let b = SignedValue::make(
         &mut context,
         Block_::<SimulatedContext> {

--- a/librabft-v2/tests/simulated_run.rs
+++ b/librabft-v2/tests/simulated_run.rs
@@ -8,6 +8,7 @@ use bft_lib::{
     interfaces::ConsensusNode,
     simulated_context::{SimulatedContext, State},
     simulator,
+    smr_context::StateFinalizer,
 };
 use futures::executor::block_on;
 use librabft_v2::{
@@ -26,16 +27,14 @@ fn make_simulator(
     DataSyncResponse<SimulatedContext>,
 > {
     let context_factory = |author, num_nodes| {
-        let mut context =
-            SimulatedContext::new(author, std::collections::HashMap::new(), num_nodes, 30000);
+        let mut context = SimulatedContext::new(author, num_nodes, 30000);
         let config = NodeConfig {
             target_commit_interval: Duration(100000),
             delta: Duration(20),
-            gamma_times_100: 200,
-            lambda_times_100: 50,
+            gamma: 2.0,
+            lambda: 0.5,
         };
-        let initial_state = context.last_committed_state();
-        let mut node = NodeState::new(author, config, initial_state, NodeTime(0), &context);
+        let mut node = NodeState::make_initial_state(&context, config, NodeTime(0));
         block_on(node.save_node(&mut context)).unwrap();
         context
     };

--- a/librabft-v2/tests/simulated_run.rs
+++ b/librabft-v2/tests/simulated_run.rs
@@ -13,17 +13,15 @@ use librabft_v2::{
     node::{NodeConfig, NodeState},
 };
 
-type Context = SimulatedContext<NodeConfig>;
-
 fn make_simulator(
     seed: u64,
     nodes: usize,
 ) -> simulator::Simulator<
-    NodeState<Context>,
-    Context,
-    DataSyncNotification<Context>,
+    NodeState<SimulatedContext>,
+    SimulatedContext,
+    DataSyncNotification<SimulatedContext>,
     DataSyncRequest,
-    DataSyncResponse<Context>,
+    DataSyncResponse<SimulatedContext>,
 > {
     let context_factory = |author, num_nodes| {
         let config = NodeConfig {
@@ -32,7 +30,9 @@ fn make_simulator(
             gamma_times_100: 200,
             lambda_times_100: 50,
         };
-        SimulatedContext::new(author, config, num_nodes, 30000)
+        let mut database = std::collections::HashMap::new();
+        database.insert("config".to_string(), serde_json::to_vec(&config).unwrap());
+        SimulatedContext::new(author, database, num_nodes, 30000)
     };
     let delay_distribution = simulator::RandomDelay::new(10.0, 4.0);
     simulator::Simulator::new(seed, nodes, delay_distribution, context_factory)


### PR DESCRIPTION
Initial implementation of persistence for LibraBFTv2:
* The entire state of a node is persisted every time (this is inefficient of course but I believe this is the correct semantic and the remaining work can be seen as optimizations)
* Clarify storage interfaces (in particular, remove the parameter `Config`, which should help with https://github.com/novifinancial/librabft_simulator/pull/4)

Misc:
* Address TODO for error handling (only local storage APIs are async and faillible in the end. For networking, we may just ignore invalid data)
* Remove field `local_author` in LBFTv2 (use `context.author()` instead)